### PR TITLE
Render rect with fx_renderer

### DIFF
--- a/include/sway/desktop/fx_renderer.h
+++ b/include/sway/desktop/fx_renderer.h
@@ -48,4 +48,6 @@ bool fx_render_subtexture_with_matrix(struct fx_renderer *renderer,
 bool fx_render_texture_with_matrix(struct fx_renderer *renderer,
 		struct wlr_texture *wlr_texture, const float matrix[static 9], float alpha);
 
+void fx_render_rect(struct fx_renderer *renderer, const struct wlr_box *box, const float color[static 4], const float projection[static 9]);
+
 #endif

--- a/sway/desktop/fx_renderer.c
+++ b/sway/desktop/fx_renderer.c
@@ -93,12 +93,6 @@ const GLchar tex_fragment_src_external[] =
   Matrix Consts
 *************************/
 
-static const GLfloat flip_180[] = {
-	1.0f, 0.0f, 0.0f,
-	0.0f, -1.0f, 0.0f,
-	0.0f, 0.0f, 1.0f,
-};
-
 static const GLfloat verts[] = {
 	1, 0, // top right
 	0, 0, // top left
@@ -396,7 +390,9 @@ void fx_render_rect(struct fx_renderer *renderer, const struct wlr_box *box, con
 
 	float gl_matrix[9];
 	wlr_matrix_multiply(gl_matrix, renderer->projection, matrix);
-	wlr_matrix_multiply(gl_matrix, flip_180, gl_matrix);
+
+    // TODO: investigate why matrix is flipped prior to this cmd
+	// wlr_matrix_multiply(gl_matrix, flip_180, gl_matrix);
 
 	wlr_matrix_transpose(gl_matrix, gl_matrix);
 

--- a/sway/desktop/fx_renderer.c
+++ b/sway/desktop/fx_renderer.c
@@ -92,13 +92,12 @@ const GLchar tex_fragment_src_external[] =
 /************************
   Matrix Consts
 *************************/
-/*
+
 static const GLfloat flip_180[] = {
 	1.0f, 0.0f, 0.0f,
 	0.0f, -1.0f, 0.0f,
 	0.0f, 0.0f, 1.0f,
 };
-*/
 
 static const GLfloat verts[] = {
 	1, 0, // top right
@@ -162,7 +161,6 @@ error:
 }
 
 // TODO: Hyprland way?
-// TODO: instead of server, have param be server->backend like wlr_renderer_autocreate
 struct fx_renderer *fx_renderer_create(struct wlr_egl *egl) {
 	struct fx_renderer *renderer = calloc(1, sizeof(struct fx_renderer));
 	if (renderer == NULL) {
@@ -260,8 +258,6 @@ error:
 }
 
 void fx_renderer_begin(struct fx_renderer *renderer, uint32_t width, uint32_t height) {
-	//push_gles2_debug(renderer);
-
 	glViewport(0, 0, width, height);
 
 	// refresh projection matrix
@@ -269,9 +265,6 @@ void fx_renderer_begin(struct fx_renderer *renderer, uint32_t width, uint32_t he
 		WL_OUTPUT_TRANSFORM_FLIPPED_180);
 
 	glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-
-	//pop_gles2_debug(renderer);
-
 }
 
 void fx_renderer_end() {
@@ -338,8 +331,6 @@ bool fx_render_subtexture_with_matrix(struct fx_renderer *renderer,
 	// to GL_FALSE
 	wlr_matrix_transpose(gl_matrix, gl_matrix);
 
-	// push_gles2_debug(renderer);
-
 	if (!texture_attrs.has_alpha && alpha == 1.0) {
 		glDisable(GL_BLEND);
 	} else {
@@ -381,7 +372,6 @@ bool fx_render_subtexture_with_matrix(struct fx_renderer *renderer,
 
 	glBindTexture(texture_attrs.target, 0);
 
-	// pop_gles2_debug(renderer);
 	return true;
 }
 
@@ -395,3 +385,39 @@ bool fx_render_texture_with_matrix(struct fx_renderer *renderer,
 	};
 	return fx_render_subtexture_with_matrix(renderer, wlr_texture, &box, matrix, alpha);
 }
+
+void fx_render_rect(struct fx_renderer *renderer, const struct wlr_box *box, const float color[static 4], const float projection[static 9]) {
+	if (box->width == 0 || box->height == 0) {
+		return;
+	}
+	assert(box->width > 0 && box->height > 0);
+	float matrix[9];
+	wlr_matrix_project_box(matrix, box, WL_OUTPUT_TRANSFORM_NORMAL, 0, projection);
+
+	float gl_matrix[9];
+	wlr_matrix_multiply(gl_matrix, renderer->projection, matrix);
+	wlr_matrix_multiply(gl_matrix, flip_180, gl_matrix);
+
+	wlr_matrix_transpose(gl_matrix, gl_matrix);
+
+	if (color[3] == 1.0) {
+		glDisable(GL_BLEND);
+	} else {
+		glEnable(GL_BLEND);
+	}
+
+	glUseProgram(renderer->shaders.quad.program);
+
+	glUniformMatrix3fv(renderer->shaders.quad.proj, 1, GL_FALSE, gl_matrix);
+	glUniform4f(renderer->shaders.quad.color, color[0], color[1], color[2], color[3]);
+
+	glVertexAttribPointer(renderer->shaders.quad.pos_attrib, 2, GL_FLOAT, GL_FALSE,
+			0, verts);
+
+	glEnableVertexAttribArray(renderer->shaders.quad.pos_attrib);
+
+	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+	glDisableVertexAttribArray(renderer->shaders.quad.pos_attrib);
+}
+

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -218,7 +218,7 @@ void render_rect(struct sway_output *output,
 		pixman_region32_t *output_damage, const struct wlr_box *_box,
 		float color[static 4]) {
 	struct wlr_output *wlr_output = output->wlr_output;
-	struct wlr_renderer *renderer = wlr_output->renderer;
+	struct fx_renderer *renderer = output->server->renderer;
 
 	struct wlr_box box;
 	memcpy(&box, _box, sizeof(struct wlr_box));
@@ -239,7 +239,7 @@ void render_rect(struct sway_output *output,
 	pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);
 	for (int i = 0; i < nrects; ++i) {
 		scissor_output(wlr_output, &rects[i]);
-		wlr_render_rect(renderer, &box, color,
+		fx_render_rect(renderer, &box, color,
 			wlr_output->transform_matrix);
 	}
 
@@ -1028,7 +1028,6 @@ static void render_seatops(struct sway_output *output,
 void output_render(struct sway_output *output, struct timespec *when,
 		pixman_region32_t *damage) {
 	struct wlr_output *wlr_output = output->wlr_output;
-	struct wlr_renderer *wlr_renderer = output->server->wlr_renderer;
 	struct fx_renderer *renderer = output->server->renderer;
 
 	struct sway_workspace *workspace = output->current.active_workspace;
@@ -1141,6 +1140,7 @@ render_overlay:
 	render_drag_icons(output, damage, &root->drag_icons);
 
 renderer_end:
+	struct wlr_renderer *wlr_renderer = output->server->wlr_renderer;
 	fx_renderer_scissor(NULL);
 	wlr_renderer_begin(wlr_renderer, wlr_output->width, wlr_output->height);
 	wlr_output_render_software_cursors(wlr_output, damage);


### PR DESCRIPTION
This PR will allow fx_renderer to render titlebars and borders, which means that it will completely replace wlr_renderer in rendering to the screen.