### PR TITLE
Improve Nix Flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,21 @@ Sway is an incredible window manager, and certainly one of the most well establi
 
 ## Installation
 
-### Compiling from Source
+### Nix
 
-This project contains a nix flake for those who have the nix package manager installed. This flake handles installing the below dependencies when `nix develop` is ran inside of the project root. Otherwise, the below dependencies must be installed prior to building and running this project.
+If you have Nix installed, you can run SwayFX with a single command:
+
+```
+nix run github:WillPower3309/swayfx
+```
+
+You can also bring up a development shell and follow the build instructions below, without installing all of the dependencies manually:
+
+```
+nix develop
+```
+
+### Compiling from Source
 
 Install dependencies:
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,39 +1,181 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
-        "lastModified": 1649676176,
-        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "lib-aggregate": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1668341496,
+        "narHash": "sha256-RztQBdjzVOG8TRoWikG62//kPcC1JSHaqYeM+UFl46k=",
+        "owner": "nix-community",
+        "repo": "lib-aggregate",
+        "rev": "0d285b79d0478307e5e180161174169263bea84a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "lib-aggregate",
+        "type": "github"
+      }
+    },
+    "nix-eval-jobs": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs-wayland",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1668390437,
+        "narHash": "sha256-NLH+7Wl/xLCBhqOPsMOXzcBv/lTGv9xFNQ1G1GShmIY=",
+        "owner": "nix-community",
+        "repo": "nix-eval-jobs",
+        "rev": "4777023e8661e320bbad87992741b7b3aeda9c86",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-eval-jobs",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651024496,
-        "narHash": "sha256-uKSrrw/neSkxX6TXPSaMyfu7iKzFrK7F6HOt6vQefGY=",
-        "owner": "NixOS",
+        "lastModified": 1668531822,
+        "narHash": "sha256-rNt2SphDCQTbAgWBX9ZCMIn5ISxeb0l6b6kRLvzbFVo=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d9e593ed5889f3906dc72811c45bf684be8865cf",
+        "rev": "97b8d9459f7922ce0e666113a1e8e6071424ae16",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "nixos",
         "ref": "nixpkgs-unstable",
-        "type": "indirect"
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1668300937,
+        "narHash": "sha256-E9/ir9++M58btaHOqugyrE4lfVnM0gIq5M9QWhGX0aM=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "41386dc5b4915d0d5716e9d09dbf372ea3bd24f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-wayland": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "lib-aggregate": "lib-aggregate",
+        "nix-eval-jobs": "nix-eval-jobs",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1668505865,
+        "narHash": "sha256-FSZP6p/1CVSrs2LJDqhBY+qoeSgVF3FJMW92PFbIIK8=",
+        "owner": "nix-community",
+        "repo": "nixpkgs-wayland",
+        "rev": "be8fc14a1ca068567ea4bc3fe6e8e5519efd8a3f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs-wayland",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1668417584,
+        "narHash": "sha256-yeuEyxKPwsm5fIHN49L/syn9g5coxnPp3GsVquhrv5A=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "013fcdd106823416918004bb684c3c186d3c460f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-wayland": "nixpkgs-wayland"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -16,93 +16,6 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "lib-aggregate": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1668341496,
-        "narHash": "sha256-RztQBdjzVOG8TRoWikG62//kPcC1JSHaqYeM+UFl46k=",
-        "owner": "nix-community",
-        "repo": "lib-aggregate",
-        "rev": "0d285b79d0478307e5e180161174169263bea84a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "lib-aggregate",
-        "type": "github"
-      }
-    },
-    "nix-eval-jobs": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": [
-          "nixpkgs-wayland",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1668390437,
-        "narHash": "sha256-NLH+7Wl/xLCBhqOPsMOXzcBv/lTGv9xFNQ1G1GShmIY=",
-        "owner": "nix-community",
-        "repo": "nix-eval-jobs",
-        "rev": "4777023e8661e320bbad87992741b7b3aeda9c86",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nix-eval-jobs",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1668531822,
@@ -119,63 +32,10 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1668300937,
-        "narHash": "sha256-E9/ir9++M58btaHOqugyrE4lfVnM0gIq5M9QWhGX0aM=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "41386dc5b4915d0d5716e9d09dbf372ea3bd24f3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-wayland": {
-      "inputs": {
-        "flake-compat": "flake-compat_2",
-        "lib-aggregate": "lib-aggregate",
-        "nix-eval-jobs": "nix-eval-jobs",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1668505865,
-        "narHash": "sha256-FSZP6p/1CVSrs2LJDqhBY+qoeSgVF3FJMW92PFbIIK8=",
-        "owner": "nix-community",
-        "repo": "nixpkgs-wayland",
-        "rev": "be8fc14a1ca068567ea4bc3fe6e8e5519efd8a3f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs-wayland",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1668417584,
-        "narHash": "sha256-yeuEyxKPwsm5fIHN49L/syn9g5coxnPp3GsVquhrv5A=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "013fcdd106823416918004bb684c3c186d3c460f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-wayland": "nixpkgs-wayland"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -8,15 +8,14 @@
     };
 
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    nixpkgs-wayland.url = "github:nix-community/nixpkgs-wayland";
   };
 
-  outputs = { self, nixpkgs, flake-compat, nixpkgs-wayland, ... }:
+  outputs = { self, nixpkgs, flake-compat, ... }:
     let
       pkgsFor = system:
         import nixpkgs {
           inherit system;
-          overlays = [ nixpkgs-wayland.overlay ];
+          overlays = [ ];
         };
 
       targetSystems = [ "aarch64-linux" "x86_64-linux" ];

--- a/flake.nix
+++ b/flake.nix
@@ -2,33 +2,88 @@
   description = "swaywm development environment";
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixpkgs-unstable";
-    flake-utils = { url = "github:numtide/flake-utils"; };
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs-wayland.url = "github:nix-community/nixpkgs-wayland";
   };
 
-  outputs = {self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-
-      in {
-        devShell = pkgs.mkShell {
-          depsBuildBuild = with pkgs; [
-            pkg-config
-          ];
- 
-          nativeBuildInputs = with pkgs; [
-            cmake meson ninja pkg-config wayland-scanner scdoc
-          ];
-
-          buildInputs = with pkgs; [
-            wayland libxkbcommon pcre json_c libevdev pango cairo libinput libcap pam gdk-pixbuf librsvg
-            wayland-protocols libdrm wlroots dbus xwayland
-            # wlroots
-            libGL pixman xorg.xcbutilwm xorg.libX11 libcap xorg.xcbutilimage xorg.xcbutilerrors mesa
-            libpng ffmpeg xorg.xcbutilrenderutil seatd
-          ];
+  outputs = { self, nixpkgs, flake-compat, nixpkgs-wayland, ... }:
+    let
+      pkgsFor = system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ nixpkgs-wayland.overlay ];
         };
-      }
-    );
+
+      targetSystems = [ "aarch64-linux" "x86_64-linux" ];
+    in {
+      overlays.default = final: prev: {
+        swayfx = prev.sway.overrideAttrs (old: {
+          version = "999-master";
+          src = builtins.path {
+            name = "swayfx";
+            path = prev.lib.cleanSource ./.;
+          };
+        });
+      };
+
+      packages = nixpkgs.lib.genAttrs targetSystems (system:
+        let pkgs = pkgsFor system;
+        in (self.overlays.default pkgs pkgs) // {
+          default = self.packages.${system}.swayfx;
+        });
+
+      devShells = nixpkgs.lib.genAttrs targetSystems (system:
+        let pkgs = pkgsFor system;
+        in {
+          default = pkgs.mkShell {
+            depsBuildBuild = with pkgs; [ pkg-config ];
+
+            nativeBuildInputs = with pkgs; [
+              cmake
+              meson
+              ninja
+              pkg-config
+              wayland-scanner
+              scdoc
+            ];
+
+            buildInputs = with pkgs; [
+              wayland
+              libxkbcommon
+              pcre
+              json_c
+              libevdev
+              pango
+              cairo
+              libinput
+              libcap
+              pam
+              gdk-pixbuf
+              librsvg
+              wayland-protocols
+              libdrm
+              wlroots
+              dbus
+              xwayland
+              libGL
+              pixman
+              xorg.xcbutilwm
+              xorg.libX11
+              libcap
+              xorg.xcbutilimage
+              xorg.xcbutilerrors
+              mesa
+              libpng
+              ffmpeg
+              xorg.xcbutilrenderutil
+              seatd
+            ];
+          };
+        });
+    };
 }


### PR DESCRIPTION
This PR improves the flake support of the project. Not only will it provide a development shell, but it can also provide the build of `swayfx` itself.

To get the devshell:
`nix develop`

To run swayfx:
`nix run`

One can also add this repo as a flake input to their system configuration, and use swayfx as a package very easily.

I also went ahead and updated the README.

If you want to try out the flake for this PR, you don't even need to check it out. Just run the following:

```
nix run github:javacafe01/swayfx/nixflake
```

