### PR TITLE
Fix Nix Flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ Sway is an incredible window manager, and certainly one of the most well establi
 
 ### Nix
 
-If you have Nix installed, you can run SwayFX with a single command:
+If you have Nix installed, you can build and run SwayFX easily:
 
 ```
-nix run github:WillPower3309/swayfx
+nix build
+./result/bin/sway
 ```
 
 You can also bring up a development shell and follow the build instructions below, without installing all of the dependencies manually:

--- a/flake.nix
+++ b/flake.nix
@@ -17,21 +17,14 @@
       pkgsFor = system:
         import nixpkgs {
           inherit system;
-          overlays = [
-            (final: prev:
-              let inherit (final) system;
-              in { wlroots-old = prev.wlroots; })
-          ];
+          overlays = [ ];
         };
 
       targetSystems = [ "aarch64-linux" "x86_64-linux" ];
     in {
       overlays.default = final: prev: {
-        swayfx =
-          prev.sway-unwrapped.overrideAttrs
-          (old: {
-            src = builtins.path { path = prev.lib.cleanSource ./.; };
-          });
+        swayfx = prev.sway-unwrapped.overrideAttrs
+          (old: { src = builtins.path { path = prev.lib.cleanSource ./.; }; });
       };
 
       packages = nixpkgs.lib.genAttrs targetSystems (system:

--- a/flake.nix
+++ b/flake.nix
@@ -12,22 +12,26 @@
 
   outputs = { self, nixpkgs, flake-compat, ... }:
     let
+      inherit (nixpkgs) lib;
+
       pkgsFor = system:
         import nixpkgs {
           inherit system;
-          overlays = [ ];
+          overlays = [
+            (final: prev:
+              let inherit (final) system;
+              in { wlroots-old = prev.wlroots; })
+          ];
         };
 
       targetSystems = [ "aarch64-linux" "x86_64-linux" ];
     in {
       overlays.default = final: prev: {
-        swayfx = prev.sway.overrideAttrs (old: {
-          version = "999-master";
-          src = builtins.path {
-            name = "swayfx";
-            path = prev.lib.cleanSource ./.;
-          };
-        });
+        swayfx =
+          prev.sway-unwrapped.overrideAttrs
+          (old: {
+            src = builtins.path { path = prev.lib.cleanSource ./.; };
+          });
       };
 
       packages = nixpkgs.lib.genAttrs targetSystems (system:

--- a/flake.nix
+++ b/flake.nix
@@ -23,20 +23,21 @@
       targetSystems = [ "aarch64-linux" "x86_64-linux" ];
     in {
       overlays.default = final: prev: {
-        swayfx = prev.sway-unwrapped.overrideAttrs
+        swayfx-unwrapped = prev.sway-unwrapped.overrideAttrs
           (old: { src = builtins.path { path = prev.lib.cleanSource ./.; }; });
       };
 
       packages = nixpkgs.lib.genAttrs targetSystems (system:
         let pkgs = pkgsFor system;
         in (self.overlays.default pkgs pkgs) // {
-          default = self.packages.${system}.swayfx;
+          default = self.packages.${system}.swayfx-unwrapped;
         });
 
       devShells = nixpkgs.lib.genAttrs targetSystems (system:
         let pkgs = pkgsFor system;
         in {
           default = pkgs.mkShell {
+            name = "swayfx-shell";
             depsBuildBuild = with pkgs; [ pkg-config ];
 
             nativeBuildInputs = with pkgs; [
@@ -48,37 +49,7 @@
               scdoc
             ];
 
-            buildInputs = with pkgs; [
-              wayland
-              libxkbcommon
-              pcre
-              json_c
-              libevdev
-              pango
-              cairo
-              libinput
-              libcap
-              pam
-              gdk-pixbuf
-              librsvg
-              wayland-protocols
-              libdrm
-              wlroots
-              dbus
-              xwayland
-              libGL
-              pixman
-              xorg.xcbutilwm
-              xorg.libX11
-              libcap
-              xorg.xcbutilimage
-              xorg.xcbutilerrors
-              mesa
-              libpng
-              ffmpeg
-              xorg.xcbutilrenderutil
-              seatd
-            ];
+            inputsFrom = [ self.packages.${system}.swayfx-unwrapped ];
           };
         });
     };


### PR DESCRIPTION
Sorry for the second quick Nix flake PR :smile: 

I actually realized I overwrote the wrong sway pkg. In this PR, I instead used `sway-unwrapped`.

However, if this project were to catch up to upstream in terms of dependency versions (like wlroots), the flake will need to be updated. You can ping me whenever this happens.

Because we are using sway-unwrapped (the derivation will look for `sway-unwrapped` when the binary name is actually `sway`), we cannot directly run the project. However, we can build it with `nix build` and run the result. I updated the readme to reflect this.