### PR TITLE
[Feature] Dim inactive windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Sway is an incredible window manager, and certainly one of the most well established wayland window managers. However, it is restricted to only include the functionality that existed in i3. This fork ditches the simple wlr_renderer, and replaces it with our fx_renderer, capable of rendering with fancy GLES2 effects. This, along with a couple of minor changes, expands sway's featureset to include the following:
 
 + **Anti-aliased rounded corners, borders, and titlebars**
++ **Dim unfocused windows**
 + **Per application saturation control**: Allows the user to set the saturation (Digital Vibrance) for specific applications. Great for some FPS games!
 + **Scratchpad treated as minimize**: Allows docks, or panels with a taskbar, to correctly interpret minimize / unminimize requests ([thanks to LCBCrion](https://github.com/swaywm/sway/issues/6457))
 + **Add a nix flake to the repo**: Allows nixos users to easily contribute to and test this project

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Sway is an incredible window manager, and certainly one of the most well establi
 
 + Corner radius: `corner_radius <val>`
 + Application saturation: `for_window [CRITERIA HERE] saturation <set|plus|minus> <val 0.0 <-> 2.0>`
++ Dim unfocused windows: 
+    - `dim_inactive <float value 0.0 - 1.0>`
+    - `dim_inactive_colors.unfocused <hex color> ex, #000000FF`
+    - `dim_inactive_colors.urgent <hex color> ex, #900000FF`
 
 ## Roadmap
 

--- a/config.in
+++ b/config.in
@@ -24,6 +24,9 @@ set $menu dmenu_path | dmenu | xargs swaymsg exec --
 # window corner radius in px
 corner_radius 10
 
+# inactive window fade amount. 1.0 = no fade, 0.0 = fully faded
+dim_inactive 1.0
+
 ### Output configuration
 #
 # Default wallpaper (more resolutions are available in @datadir@/backgrounds/sway/)

--- a/config.in
+++ b/config.in
@@ -24,8 +24,10 @@ set $menu dmenu_path | dmenu | xargs swaymsg exec --
 # window corner radius in px
 corner_radius 10
 
-# inactive window fade amount. 1.0 = no fade, 0.0 = fully faded
+# inactive window fade amount. 1.0 = no dimming, 0.0 = fully faded
 dim_inactive 1.0
+dim_inactive_colors.unfocused #000000FF
+dim_inactive_colors.urgent #900000FF
 
 ### Output configuration
 #

--- a/config.in
+++ b/config.in
@@ -24,7 +24,7 @@ set $menu dmenu_path | dmenu | xargs swaymsg exec --
 # window corner radius in px
 corner_radius 10
 
-# inactive window fade amount. 1.0 = no dimming, 0.0 = fully faded
+# inactive window fade amount. 1.0 = no dimming, 0.0 = fully dimmed
 dim_inactive 1.0
 dim_inactive_colors.unfocused #000000FF
 dim_inactive_colors.urgent #900000FF

--- a/config.in
+++ b/config.in
@@ -24,8 +24,8 @@ set $menu dmenu_path | dmenu | xargs swaymsg exec --
 # window corner radius in px
 corner_radius 10
 
-# inactive window fade amount. 1.0 = no dimming, 0.0 = fully dimmed
-dim_inactive 1.0
+# inactive window fade amount. 0.0 = no dimming, 1.0 = fully dimmed
+dim_inactive 0.0
 dim_inactive_colors.unfocused #000000FF
 dim_inactive_colors.urgent #900000FF
 

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -124,6 +124,8 @@ sway_cmd cmd_default_border;
 sway_cmd cmd_default_floating_border;
 sway_cmd cmd_default_orientation;
 sway_cmd cmd_dim_inactive;
+sway_cmd cmd_dim_inactive_colors_unfocused;
+sway_cmd cmd_dim_inactive_colors_urgent;
 sway_cmd cmd_exec;
 sway_cmd cmd_exec_always;
 sway_cmd cmd_exit;

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -123,6 +123,7 @@ sway_cmd cmd_create_output;
 sway_cmd cmd_default_border;
 sway_cmd cmd_default_floating_border;
 sway_cmd cmd_default_orientation;
+sway_cmd cmd_dim_inactive;
 sway_cmd cmd_exec;
 sway_cmd cmd_exec_always;
 sway_cmd cmd_exit;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -468,6 +468,7 @@ enum xwayland_mode {
 struct sway_config {
 	// SwayFX config options
 	int corner_radius;
+	float dim_inactive;
 
 	char *swaynag_command;
 	struct swaynag_instance swaynag_config_errors;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -469,6 +469,11 @@ struct sway_config {
 	// SwayFX config options
 	int corner_radius;
 	float dim_inactive;
+	// dim_inactive colors
+	struct {
+		float unfocused[4];
+		float urgent[4];
+	} dim_inactive_colors;
 
 	char *swaynag_command;
 	struct swaynag_instance swaynag_config_errors;

--- a/include/sway/desktop/fx_renderer.h
+++ b/include/sway/desktop/fx_renderer.h
@@ -11,6 +11,7 @@ struct decoration_data {
 	float alpha;
 	float saturation;
 	int corner_radius;
+	float dim;
 	bool has_titlebar;
 };
 
@@ -25,6 +26,7 @@ struct gles2_tex_shader {
 	GLint position;
 	GLint radius;
 	GLint saturation;
+	GLint dim;
 	GLint has_titlebar;
 };
 

--- a/include/sway/desktop/fx_renderer.h
+++ b/include/sway/desktop/fx_renderer.h
@@ -12,6 +12,7 @@ struct decoration_data {
 	float saturation;
 	int corner_radius;
 	float dim;
+	float* dim_color;
 	bool has_titlebar;
 };
 
@@ -27,6 +28,7 @@ struct gles2_tex_shader {
 	GLint radius;
 	GLint saturation;
 	GLint dim;
+	GLint dim_color;
 	GLint has_titlebar;
 };
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -58,6 +58,7 @@ static const struct cmd_handler handlers[] = {
 	{ "corner_radius", cmd_corner_radius },
 	{ "default_border", cmd_default_border },
 	{ "default_floating_border", cmd_default_floating_border },
+	{ "dim_inactive", cmd_dim_inactive },
 	{ "exec", cmd_exec },
 	{ "exec_always", cmd_exec_always },
 	{ "floating_maximum_size", cmd_floating_maximum_size },

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -59,6 +59,8 @@ static const struct cmd_handler handlers[] = {
 	{ "default_border", cmd_default_border },
 	{ "default_floating_border", cmd_default_floating_border },
 	{ "dim_inactive", cmd_dim_inactive },
+	{ "dim_inactive_colors.unfocused", cmd_dim_inactive_colors_unfocused },
+	{ "dim_inactive_colors.urgent", cmd_dim_inactive_colors_urgent },
 	{ "exec", cmd_exec },
 	{ "exec_always", cmd_exec_always },
 	{ "floating_maximum_size", cmd_floating_maximum_size },

--- a/sway/commands/dim_inactive.c
+++ b/sway/commands/dim_inactive.c
@@ -1,0 +1,21 @@
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "log.h"
+
+struct cmd_results *cmd_dim_inactive(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "dim_inactive", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	char *err;
+	float val = strtof(argv[0], &err);
+	if (*err || val < 0.0f || val > 1.0f) {
+		return cmd_results_new(CMD_INVALID, "dim_inactive float invalid");
+	}
+
+	config->dim_inactive = val;
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/commands/dim_inactive.c
+++ b/sway/commands/dim_inactive.c
@@ -2,6 +2,12 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "log.h"
+#include "sway/output.h"
+
+static void rebuild_textures_iterator(struct sway_container *con, void *data) {
+	container_update_marks_textures(con);
+	container_update_title_textures(con);
+}
 
 struct cmd_results *cmd_dim_inactive(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -16,6 +22,15 @@ struct cmd_results *cmd_dim_inactive(int argc, char **argv) {
 	}
 
 	config->dim_inactive = val;
+
+	if (config->active) {
+		root_for_each_container(rebuild_textures_iterator, NULL);
+
+		for (int i = 0; i < root->outputs->length; ++i) {
+			struct sway_output *output = root->outputs->items[i];
+			output_damage_whole(output);
+		}
+	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/dim_inactive.c
+++ b/sway/commands/dim_inactive.c
@@ -4,11 +4,6 @@
 #include "log.h"
 #include "sway/output.h"
 
-static void rebuild_textures_iterator(struct sway_container *con, void *data) {
-	container_update_marks_textures(con);
-	container_update_title_textures(con);
-}
-
 struct cmd_results *cmd_dim_inactive(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "dim_inactive", EXPECTED_EQUAL_TO, 1))) {
@@ -24,8 +19,6 @@ struct cmd_results *cmd_dim_inactive(int argc, char **argv) {
 	config->dim_inactive = val;
 
 	if (config->active) {
-		root_for_each_container(rebuild_textures_iterator, NULL);
-
 		for (int i = 0; i < root->outputs->length; ++i) {
 			struct sway_output *output = root->outputs->items[i];
 			output_damage_whole(output);

--- a/sway/commands/dim_inactive_colors.c
+++ b/sway/commands/dim_inactive_colors.c
@@ -1,0 +1,47 @@
+#include "log.h"
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/output.h"
+#include "sway/tree/container.h"
+#include "util.h"
+
+static void rebuild_textures_iterator(struct sway_container *con, void *data) {
+	container_update_marks_textures(con);
+	container_update_title_textures(con);
+}
+
+static struct cmd_results *handle_command(int argc, char **argv, char *cmd_name,
+		float config_option[4]) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, cmd_name, EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+
+	uint32_t color;
+	if (!parse_color(argv[0], &color)) {
+		return cmd_results_new(CMD_INVALID, "Invalid %s color %s",
+				cmd_name, argv[0]);
+	}
+	color_to_rgba(config_option, color);
+
+	if (config->active) {
+		root_for_each_container(rebuild_textures_iterator, NULL);
+
+		for (int i = 0; i < root->outputs->length; ++i) {
+			struct sway_output *output = root->outputs->items[i];
+			output_damage_whole(output);
+		}
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}
+
+struct cmd_results *cmd_dim_inactive_colors_unfocused(int argc, char **argv) {
+	return handle_command(argc, argv, "dim_inactive_colors.unfocused",
+			config->dim_inactive_colors.unfocused);
+}
+
+struct cmd_results *cmd_dim_inactive_colors_urgent(int argc, char **argv) {
+	return handle_command(argc, argv, "dim_inactive_colors.urgent",
+			config->dim_inactive_colors.urgent);
+}

--- a/sway/commands/dim_inactive_colors.c
+++ b/sway/commands/dim_inactive_colors.c
@@ -5,11 +5,6 @@
 #include "sway/tree/container.h"
 #include "util.h"
 
-static void rebuild_textures_iterator(struct sway_container *con, void *data) {
-	container_update_marks_textures(con);
-	container_update_title_textures(con);
-}
-
 static struct cmd_results *handle_command(int argc, char **argv, char *cmd_name,
 		float config_option[4]) {
 	struct cmd_results *error = NULL;
@@ -25,8 +20,6 @@ static struct cmd_results *handle_command(int argc, char **argv, char *cmd_name,
 	color_to_rgba(config_option, color);
 
 	if (config->active) {
-		root_for_each_container(rebuild_textures_iterator, NULL);
-
 		for (int i = 0; i < root->outputs->length; ++i) {
 			struct sway_output *output = root->outputs->items[i];
 			output_damage_whole(output);

--- a/sway/config.c
+++ b/sway/config.c
@@ -327,6 +327,9 @@ static void config_defaults(struct sway_config *config) {
 
 	// SwayFX defaults
 	config->corner_radius = 0;
+	config->dim_inactive = 1.0f;
+	color_to_rgba(config->dim_inactive_colors.unfocused, 0x000000FF);
+	color_to_rgba(config->dim_inactive_colors.urgent, 0x900000FF);
 
 	// The keysym to keycode translation
 	struct xkb_rule_names rules = {0};

--- a/sway/desktop/fx_renderer.c
+++ b/sway/desktop/fx_renderer.c
@@ -96,6 +96,7 @@ bool init_frag_shader(struct gles2_tex_shader *shader, GLuint prog) {
 	shader->tex = glGetUniformLocation(prog, "tex");
 	shader->alpha = glGetUniformLocation(prog, "alpha");
 	shader->dim = glGetUniformLocation(prog, "dim");
+	shader->dim_color = glGetUniformLocation(prog, "dim_color");
 	shader->pos_attrib = glGetAttribLocation(prog, "pos");
 	shader->tex_attrib = glGetAttribLocation(prog, "texcoord");
 	shader->size = glGetUniformLocation(prog, "size");
@@ -346,12 +347,15 @@ bool fx_render_subtexture_with_matrix(struct fx_renderer *renderer, struct wlr_t
 
 	glUseProgram(shader->program);
 
+	float* dim_color = deco_data.dim_color;
+
 	glUniformMatrix3fv(shader->proj, 1, GL_FALSE, gl_matrix);
 	glUniform1i(shader->tex, 0);
 	glUniform2f(shader->size, dst_box->width, dst_box->height);
 	glUniform2f(shader->position, dst_box->x, dst_box->y);
 	glUniform1f(shader->alpha, deco_data.alpha);
 	glUniform1f(shader->dim, deco_data.dim);
+	glUniform4f(shader->dim_color, dim_color[0], dim_color[1], dim_color[2], dim_color[3]);
 	glUniform1f(shader->has_titlebar, deco_data.has_titlebar);
 	glUniform1f(shader->saturation, deco_data.saturation);
 	glUniform1f(shader->radius, deco_data.corner_radius);

--- a/sway/desktop/fx_renderer.c
+++ b/sway/desktop/fx_renderer.c
@@ -95,6 +95,7 @@ bool init_frag_shader(struct gles2_tex_shader *shader, GLuint prog) {
 	shader->proj = glGetUniformLocation(prog, "proj");
 	shader->tex = glGetUniformLocation(prog, "tex");
 	shader->alpha = glGetUniformLocation(prog, "alpha");
+	shader->dim = glGetUniformLocation(prog, "dim");
 	shader->pos_attrib = glGetAttribLocation(prog, "pos");
 	shader->tex_attrib = glGetAttribLocation(prog, "texcoord");
 	shader->size = glGetUniformLocation(prog, "size");
@@ -350,6 +351,7 @@ bool fx_render_subtexture_with_matrix(struct fx_renderer *renderer, struct wlr_t
 	glUniform2f(shader->size, dst_box->width, dst_box->height);
 	glUniform2f(shader->position, dst_box->x, dst_box->y);
 	glUniform1f(shader->alpha, deco_data.alpha);
+	glUniform1f(shader->dim, deco_data.dim);
 	glUniform1f(shader->has_titlebar, deco_data.has_titlebar);
 	glUniform1f(shader->saturation, deco_data.saturation);
 	glUniform1f(shader->radius, deco_data.corner_radius);

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -951,10 +951,10 @@ static void render_containers_linear(struct sway_output *output,
 			bool has_titlebar = state->border == B_NORMAL;
 			struct decoration_data deco_data = {
 				.alpha = child->alpha,
-				.dim = child->current.focused ? 0.0f: 1.0f - config->dim_inactive,
 				.dim_color = view_is_urgent(view)
 								 ? config->dim_inactive_colors.urgent
 								 : config->dim_inactive_colors.unfocused,
+				.dim = child->current.focused ? 0.0f: config->dim_inactive,
 				// no corner radius if smart gaps are on and only visible view
 				.corner_radius = config->smart_gaps == SMART_GAPS_ON &&
 					view_ancestor_is_only_visible(view) ? 0 : child->corner_radius,
@@ -1048,10 +1048,10 @@ static void render_containers_tabbed(struct sway_output *output,
 	if (current->view) {
 		struct decoration_data deco_data = {
 			.alpha = current->alpha,
-			.dim = current->current.focused ? 0.0f: 1.0f - config->dim_inactive,
 			.dim_color = view_is_urgent(current->view)
 							 ? config->dim_inactive_colors.urgent
 							 : config->dim_inactive_colors.unfocused,
+			.dim = current->current.focused ? 0.0f: config->dim_inactive,
 			.corner_radius = current->corner_radius,
 			.saturation = current->saturation,
 			.has_titlebar = true,
@@ -1121,10 +1121,10 @@ static void render_containers_stacked(struct sway_output *output,
 	if (current->view) {
 		struct decoration_data deco_data = {
 			.alpha = current->alpha,
-			.dim = current->current.focused ? 0.0f: 1.0f - config->dim_inactive,
 			.dim_color = view_is_urgent(current->view)
 							 ? config->dim_inactive_colors.urgent
 							 : config->dim_inactive_colors.unfocused,
+			.dim = current->current.focused ? 0.0f: config->dim_inactive,
 			.saturation = current->saturation,
 			.corner_radius = current->corner_radius,
 			.has_titlebar = true,
@@ -1221,10 +1221,10 @@ static void render_floating_container(struct sway_output *soutput,
 		bool has_titlebar = state->border == B_NORMAL;
 		struct decoration_data deco_data = {
 			.alpha = con->alpha,
-			.dim = con->current.focused ? 0.0f: 1.0f - config->dim_inactive,
 			.dim_color = view_is_urgent(view)
 							 ? config->dim_inactive_colors.urgent
 							 : config->dim_inactive_colors.unfocused,
+			.dim = con->current.focused ? 0.0f: config->dim_inactive,
 			.saturation = con->saturation,
 			.corner_radius = con->corner_radius,
 			.has_titlebar = has_titlebar,
@@ -1377,10 +1377,10 @@ void output_render(struct sway_output *output, struct timespec *when,
 	if (focus && focus->view) {
 		struct decoration_data deco_data = {
 			.alpha = focus->alpha,
-			.dim = focus->current.focused ? 0.0f: 1.0f - config->dim_inactive,
 			.dim_color = view_is_urgent(focus->view)
 				 ? config->dim_inactive_colors.urgent
 				 : config->dim_inactive_colors.unfocused,
+			.dim = focus->current.focused ? 0.0f: config->dim_inactive,
 			.corner_radius = focus->corner_radius,
 			.saturation = focus->saturation,
 			.has_titlebar = focus->current.border == B_NORMAL,

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -930,12 +930,8 @@ static void render_containers_linear(struct sway_output *output,
 			struct wlr_texture *marks_texture;
 			struct sway_container_state *state = &child->current;
 
-			// Dim color
-			float* dim_color = config->dim_inactive_colors.unfocused;
-
 			if (view_is_urgent(view)) {
 				colors = &config->border_colors.urgent;
-				dim_color = config->dim_inactive_colors.urgent;
 				title_texture = child->title_urgent;
 				marks_texture = child->marks_urgent;
 			} else if (state->focused || parent->focused) {
@@ -956,7 +952,9 @@ static void render_containers_linear(struct sway_output *output,
 			struct decoration_data deco_data = {
 				.alpha = child->alpha,
 				.dim = child->current.focused ? 0.0f: 1.0f - config->dim_inactive,
-				.dim_color = dim_color,
+				.dim_color = view_is_urgent(view)
+								 ? config->dim_inactive_colors.urgent
+								 : config->dim_inactive_colors.unfocused,
 				// no corner radius if smart gaps are on and only visible view
 				.corner_radius = config->smart_gaps == SMART_GAPS_ON &&
 					view_ancestor_is_only_visible(view) ? 0 : child->corner_radius,
@@ -1206,12 +1204,8 @@ static void render_floating_container(struct sway_output *soutput,
 		struct wlr_texture *title_texture;
 		struct wlr_texture *marks_texture;
 
-		// Dim color
-		float *dim_color = config->dim_inactive_colors.unfocused;
-
 		if (view_is_urgent(view)) {
 			colors = &config->border_colors.urgent;
-			dim_color = config->dim_inactive_colors.urgent;
 			title_texture = con->title_urgent;
 			marks_texture = con->marks_urgent;
 		} else if (state->focused) {
@@ -1228,7 +1222,9 @@ static void render_floating_container(struct sway_output *soutput,
 		struct decoration_data deco_data = {
 			.alpha = con->alpha,
 			.dim = con->current.focused ? 0.0f: 1.0f - config->dim_inactive,
-			.dim_color = dim_color,
+			.dim_color = view_is_urgent(view)
+							 ? config->dim_inactive_colors.urgent
+							 : config->dim_inactive_colors.unfocused,
 			.saturation = con->saturation,
 			.corner_radius = con->corner_radius,
 			.has_titlebar = has_titlebar,
@@ -1382,7 +1378,9 @@ void output_render(struct sway_output *output, struct timespec *when,
 		struct decoration_data deco_data = {
 			.alpha = focus->alpha,
 			.dim = focus->current.focused ? 0.0f: 1.0f - config->dim_inactive,
-			.dim_color = config->dim_inactive_colors.unfocused,
+			.dim_color = view_is_urgent(focus->view)
+				 ? config->dim_inactive_colors.urgent
+				 : config->dim_inactive_colors.unfocused,
 			.corner_radius = focus->corner_radius,
 			.saturation = focus->saturation,
 			.has_titlebar = focus->current.border == B_NORMAL,

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -998,8 +998,6 @@ static void render_containers_tabbed(struct sway_output *output,
 	struct border_colors *current_colors = &config->border_colors.unfocused;
 	int tab_width = parent->box.width / parent->children->length;
 
-	bool is_urgent = false;
-
 	// Render tabs
 	for (int i = 0; i < parent->children->length; ++i) {
 		struct sway_container *child = parent->children->items[i];
@@ -1015,8 +1013,6 @@ static void render_containers_tabbed(struct sway_output *output,
 			colors = &config->border_colors.urgent;
 			title_texture = child->title_urgent;
 			marks_texture = child->marks_urgent;
-
-			is_urgent = true;
 		} else if (cstate->focused || parent->focused) {
 			colors = &config->border_colors.focused;
 			title_texture = child->title_focused;
@@ -1052,16 +1048,12 @@ static void render_containers_tabbed(struct sway_output *output,
 
 	// Render surface and left/right/bottom borders
 	if (current->view) {
-		// Dim color
-		float* dim_color = config->dim_inactive_colors.unfocused;
-		if (is_urgent) {
-			dim_color = config->dim_inactive_colors.urgent;
-		}
-
 		struct decoration_data deco_data = {
 			.alpha = current->alpha,
 			.dim = current->current.focused ? 0.0f: 1.0f - config->dim_inactive,
-			.dim_color = dim_color,
+			.dim_color = view_is_urgent(current->view)
+							 ? config->dim_inactive_colors.urgent
+							 : config->dim_inactive_colors.unfocused,
 			.corner_radius = current->corner_radius,
 			.saturation = current->saturation,
 			.has_titlebar = true,
@@ -1085,8 +1077,6 @@ static void render_containers_stacked(struct sway_output *output,
 	struct border_colors *current_colors = &config->border_colors.unfocused;
 	size_t titlebar_height = container_titlebar_height();
 
-	bool is_urgent = false;
-
 	// Render titles
 	for (int i = 0; i < parent->children->length; ++i) {
 		struct sway_container *child = parent->children->items[i];
@@ -1102,8 +1092,6 @@ static void render_containers_stacked(struct sway_output *output,
 			colors = &config->border_colors.urgent;
 			title_texture = child->title_urgent;
 			marks_texture = child->marks_urgent;
-
-			is_urgent = true;
 		} else if (cstate->focused || parent->focused) {
 			colors = &config->border_colors.focused;
 			title_texture = child->title_focused;
@@ -1133,16 +1121,12 @@ static void render_containers_stacked(struct sway_output *output,
 
 	// Render surface and left/right/bottom borders
 	if (current->view) {
-		// Dim color
-		float* dim_color = config->dim_inactive_colors.unfocused;
-		if (is_urgent) {
-			dim_color = config->dim_inactive_colors.urgent;
-		}
-
 		struct decoration_data deco_data = {
 			.alpha = current->alpha,
 			.dim = current->current.focused ? 0.0f: 1.0f - config->dim_inactive,
-			.dim_color = dim_color,
+			.dim_color = view_is_urgent(current->view)
+							 ? config->dim_inactive_colors.urgent
+							 : config->dim_inactive_colors.unfocused,
 			.saturation = current->saturation,
 			.corner_radius = current->corner_radius,
 			.has_titlebar = true,

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -39,6 +39,7 @@ struct render_data {
 struct decoration_data get_undecorated_decoration_data() {
 	return (struct decoration_data) {
 		.alpha = 1.0f,
+		.dim = 0.0f,
 		.corner_radius = 0,
 		.saturation = 1.0f,
 		.has_titlebar = false,
@@ -949,6 +950,7 @@ static void render_containers_linear(struct sway_output *output,
 			bool has_titlebar = state->border == B_NORMAL;
 			struct decoration_data deco_data = {
 				.alpha = child->alpha,
+				.dim = child->current.focused ? 0.0f: 1.0f - config->dim_inactive,
 				// no corner radius if smart gaps are on and only visible view
 				.corner_radius = config->smart_gaps == SMART_GAPS_ON &&
 					view_ancestor_is_only_visible(view) ? 0 : child->corner_radius,
@@ -1042,6 +1044,7 @@ static void render_containers_tabbed(struct sway_output *output,
 	if (current->view) {
 		struct decoration_data deco_data = {
 			.alpha = current->alpha,
+			.dim = current->current.focused ? 0.0f: 1.0f - config->dim_inactive,
 			.corner_radius = current->corner_radius,
 			.saturation = current->saturation,
 			.has_titlebar = true,
@@ -1111,6 +1114,7 @@ static void render_containers_stacked(struct sway_output *output,
 	if (current->view) {
 		struct decoration_data deco_data = {
 			.alpha = current->alpha,
+			.dim = current->current.focused ? 0.0f: 1.0f - config->dim_inactive,
 			.saturation = current->saturation,
 			.corner_radius = current->corner_radius,
 			.has_titlebar = true,
@@ -1207,6 +1211,7 @@ static void render_floating_container(struct sway_output *soutput,
 		bool has_titlebar = state->border == B_NORMAL;
 		struct decoration_data deco_data = {
 			.alpha = con->alpha,
+			.dim = con->current.focused ? 0.0f: 1.0f - config->dim_inactive,
 			.saturation = con->saturation,
 			.corner_radius = con->corner_radius,
 			.has_titlebar = has_titlebar,
@@ -1359,6 +1364,7 @@ void output_render(struct sway_output *output, struct timespec *when,
 	if (focus && focus->view) {
 		struct decoration_data deco_data = {
 			.alpha = focus->alpha,
+			.dim = focus->current.focused ? 0.0f: 1.0f - config->dim_inactive,
 			.corner_radius = focus->corner_radius,
 			.saturation = focus->saturation,
 			.has_titlebar = focus->current.border == B_NORMAL,

--- a/sway/desktop/shaders/tex_external.frag
+++ b/sway/desktop/shaders/tex_external.frag
@@ -15,15 +15,16 @@ uniform float saturation;
 const vec3 saturation_weight = vec3(0.2125, 0.7154, 0.0721);
 
 void main() {
+    vec4 color = texture2D(texture0, v_texcoord);
     // Saturation
     if (saturation != 1.0) {
         vec4 pixColor = texture2D(texture0, v_texcoord);
         vec3 irgb = pixColor.rgb;
         vec3 target = vec3(dot(irgb, saturation_weight));
-        gl_FragColor = vec4(mix(target, irgb, saturation), pixColor.a) * alpha;
-    } else {
-        gl_FragColor = mix(texture2D(texture0, v_texcoord), dim_color, dim) * alpha;
+        color = vec4(mix(target, irgb, saturation), pixColor.a);
     }
+    // Dimming
+    gl_FragColor = mix(color, dim_color, dim) * alpha;
 
     if (!has_titlebar || gl_FragCoord.y - position.y > radius) {
         vec2 corner_distance = min(gl_FragCoord.xy - position, size + position - gl_FragCoord.xy);

--- a/sway/desktop/shaders/tex_external.frag
+++ b/sway/desktop/shaders/tex_external.frag
@@ -5,6 +5,7 @@ varying vec2 v_texcoord;
 uniform samplerExternalOES texture0;
 uniform float alpha;
 uniform float dim;
+uniform vec4 dim_color;
 
 uniform vec2 size;
 uniform vec2 position;
@@ -21,9 +22,7 @@ void main() {
         vec3 target = vec3(dot(irgb, saturation_weight));
         gl_FragColor = vec4(mix(target, irgb, saturation), pixColor.a) * alpha;
     } else {
-        gl_FragColor = mix(
-            texture2D(texture0, v_texcoord), vec4(0.0, 0.0, 0.0, 1.0), dim)
-            * alpha;
+        gl_FragColor = mix(texture2D(texture0, v_texcoord), dim_color, dim) * alpha;
     }
 
     if (!has_titlebar || gl_FragCoord.y - position.y > radius) {

--- a/sway/desktop/shaders/tex_external.frag
+++ b/sway/desktop/shaders/tex_external.frag
@@ -4,6 +4,7 @@ precision mediump float;
 varying vec2 v_texcoord;
 uniform samplerExternalOES texture0;
 uniform float alpha;
+uniform float dim;
 
 uniform vec2 size;
 uniform vec2 position;
@@ -20,7 +21,9 @@ void main() {
         vec3 target = vec3(dot(irgb, saturation_weight));
         gl_FragColor = vec4(mix(target, irgb, saturation), pixColor.a) * alpha;
     } else {
-        gl_FragColor = texture2D(texture0, v_texcoord) * alpha;
+        gl_FragColor = mix(
+            texture2D(texture0, v_texcoord), vec4(0.0, 0.0, 0.0, 1.0), dim)
+            * alpha;
     }
 
     if (!has_titlebar || gl_FragCoord.y - position.y > radius) {

--- a/sway/desktop/shaders/tex_rgba.frag
+++ b/sway/desktop/shaders/tex_rgba.frag
@@ -3,6 +3,7 @@ varying vec2 v_texcoord;
 uniform sampler2D tex;
 uniform float alpha;
 uniform float dim;
+uniform vec4 dim_color;
 
 uniform vec2 size;
 uniform vec2 position;
@@ -19,9 +20,7 @@ void main() {
         vec3 target = vec3(dot(irgb, saturation_weight));
         gl_FragColor = vec4(mix(target, irgb, saturation), pixColor.a) * alpha;
     } else {
-        gl_FragColor = mix(
-            texture2D(tex, v_texcoord), vec4(0.0, 0.0, 0.0, 1.0), dim)
-            * alpha;
+        gl_FragColor = mix(texture2D(tex, v_texcoord), dim_color, dim) * alpha;
     }
 
     if (!has_titlebar || gl_FragCoord.y - position.y > radius) {

--- a/sway/desktop/shaders/tex_rgba.frag
+++ b/sway/desktop/shaders/tex_rgba.frag
@@ -13,15 +13,16 @@ uniform float saturation;
 const vec3 saturation_weight = vec3(0.2125, 0.7154, 0.0721);
 
 void main() {
+    vec4 color = texture2D(tex, v_texcoord);
     // Saturation
     if (saturation != 1.0) {
         vec4 pixColor = texture2D(tex, v_texcoord);
         vec3 irgb = pixColor.rgb;
         vec3 target = vec3(dot(irgb, saturation_weight));
-        gl_FragColor = vec4(mix(target, irgb, saturation), pixColor.a) * alpha;
-    } else {
-        gl_FragColor = mix(texture2D(tex, v_texcoord), dim_color, dim) * alpha;
+        color = vec4(mix(target, irgb, saturation), pixColor.a);
     }
+    // Dimming
+    gl_FragColor = mix(color, dim_color, dim) * alpha;
 
     if (!has_titlebar || gl_FragCoord.y - position.y > radius) {
         vec2 corner_distance = min(gl_FragCoord.xy - position, size + position - gl_FragCoord.xy);

--- a/sway/desktop/shaders/tex_rgba.frag
+++ b/sway/desktop/shaders/tex_rgba.frag
@@ -2,6 +2,7 @@ precision mediump float;
 varying vec2 v_texcoord;
 uniform sampler2D tex;
 uniform float alpha;
+uniform float dim;
 
 uniform vec2 size;
 uniform vec2 position;
@@ -18,7 +19,9 @@ void main() {
         vec3 target = vec3(dot(irgb, saturation_weight));
         gl_FragColor = vec4(mix(target, irgb, saturation), pixColor.a) * alpha;
     } else {
-        gl_FragColor = texture2D(tex, v_texcoord) * alpha;
+        gl_FragColor = mix(
+            texture2D(tex, v_texcoord), vec4(0.0, 0.0, 0.0, 1.0), dim)
+            * alpha;
     }
 
     if (!has_titlebar || gl_FragCoord.y - position.y > radius) {

--- a/sway/desktop/shaders/tex_rgbx.frag
+++ b/sway/desktop/shaders/tex_rgbx.frag
@@ -3,6 +3,7 @@ varying vec2 v_texcoord;
 uniform sampler2D tex;
 uniform float alpha;
 uniform float dim;
+uniform vec4 dim_color;
 
 uniform vec2 size;
 uniform vec2 position;
@@ -19,9 +20,7 @@ void main() {
         gl_FragColor = vec4(mix(target, irgb, saturation), 1.0) * alpha;
     } else {
         gl_FragColor = mix(
-            vec4(texture2D(tex, v_texcoord).rgb, 1.0),
-            vec4(0.0, 0.0, 0.0, 1.0), dim)
-            * alpha;
+            vec4(texture2D(tex, v_texcoord).rgb, 1.0), dim_color, dim) * alpha;
     }
 
     if (!has_titlebar || gl_FragCoord.y - position.y > radius) {

--- a/sway/desktop/shaders/tex_rgbx.frag
+++ b/sway/desktop/shaders/tex_rgbx.frag
@@ -13,15 +13,15 @@ uniform float saturation;
 const vec3 saturation_weight = vec3(0.2125, 0.7154, 0.0721);
 
 void main() {
+    vec4 color = vec4(texture2D(tex, v_texcoord).rgb, 1.0);
     // Saturation
     if (saturation != 1.0) {
         vec3 irgb = texture2D(tex, v_texcoord).rgb;
         vec3 target = vec3(dot(irgb, saturation_weight));
-        gl_FragColor = vec4(mix(target, irgb, saturation), 1.0) * alpha;
-    } else {
-        gl_FragColor = mix(
-            vec4(texture2D(tex, v_texcoord).rgb, 1.0), dim_color, dim) * alpha;
+        color = vec4(mix(target, irgb, saturation), 1.0);
     }
+    // Dimming
+    gl_FragColor = mix(color, dim_color, dim) * alpha;
 
     if (!has_titlebar || gl_FragCoord.y - position.y > radius) {
         vec2 corner_distance = min(gl_FragCoord.xy - position, size + position - gl_FragCoord.xy);

--- a/sway/desktop/shaders/tex_rgbx.frag
+++ b/sway/desktop/shaders/tex_rgbx.frag
@@ -2,6 +2,7 @@ precision mediump float;
 varying vec2 v_texcoord;
 uniform sampler2D tex;
 uniform float alpha;
+uniform float dim;
 
 uniform vec2 size;
 uniform vec2 position;
@@ -17,7 +18,10 @@ void main() {
         vec3 target = vec3(dot(irgb, saturation_weight));
         gl_FragColor = vec4(mix(target, irgb, saturation), 1.0) * alpha;
     } else {
-        gl_FragColor = vec4(texture2D(tex, v_texcoord).rgb, 1.0) * alpha;
+        gl_FragColor = mix(
+            vec4(texture2D(tex, v_texcoord).rgb, 1.0),
+            vec4(0.0, 0.0, 0.0, 1.0), dim)
+            * alpha;
     }
 
     if (!has_titlebar || gl_FragCoord.y - position.y > radius) {

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -51,6 +51,7 @@ sway_sources = files(
     'commands/default_border.c',
     'commands/default_floating_border.c',
     'commands/default_orientation.c',
+    'commands/dim_inactive.c',
     'commands/exit.c',
     'commands/exec.c',
     'commands/exec_always.c',

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -52,6 +52,7 @@ sway_sources = files(
     'commands/default_floating_border.c',
     'commands/default_orientation.c',
     'commands/dim_inactive.c',
+    'commands/dim_inactive_colors.c',
     'commands/exit.c',
     'commands/exec.c',
     'commands/exec_always.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -588,6 +588,16 @@ The default colors are:
 *corner_radius* <radius>
 	Set corner radius for new windows.
 
+*dim_inactive* <value>
+	Adjusts the dimming of inactive windows between 0.0 (fully dimmed) and 1.0 (no dimming) while 1 is
+	the default value.
+
+*dim_inactive_colors.unfocused* <hex color>
+	The color to dim inactive windows with. Example color: #000000FF
+
+*dim_inactive_colors.urgent* <hex color>
+	The color to dim inactive urgent windows with. Example color: #900000FF
+
 *default_border* normal|none|pixel [<n>]
 	Set default border style for new tiled windows.
 

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -589,8 +589,8 @@ The default colors are:
 	Set corner radius for new windows.
 
 *dim_inactive* <value>
-	Adjusts the dimming of inactive windows between 0.0 (fully dimmed) and 1.0 (no dimming) while 1 is
-	the default value.
+	Adjusts the dimming of inactive windows between 0.0 (no dimming) and 1.0
+	(fully dimmed) while 0.0 is the default value.
 
 *dim_inactive_colors.unfocused* <hex color>
 	The color to dim inactive windows with. Example color: #000000FF


### PR DESCRIPTION
Fixes: #63 

Adds `dim_inactive`, `dim_inactive_colors.unfocused` and `dim_inactive_colors.urgent` config options

Todo:

- [x] Initial implementation
- [x] "Hot-reload" option with swaymsg
- [x] Choose which color to fade the window with
  - [x] Urgency color
- [x] README
- [x] Man page

The dim color is atm fixed to black. I'm not sure where the best place would be for a color config option...

With a value of 0.5:

![image](https://user-images.githubusercontent.com/35975961/204642858-fe265304-ddd7-4a91-b894-470a95404a28.png)