### PR TITLE
Fixed top and bottom borders being too large

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -511,10 +511,11 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 		box.y = floor(state->content_y + state->content_height);
 		box.width = state->width;
 		box.height = state->border_thickness;
+
 		// adjust sizing for rounded border corners
 		if (deco_data.corner_radius) {
-			box.x += deco_data.corner_radius;
-			box.width -= 2 * deco_data.corner_radius;
+			box.x += deco_data.corner_radius + state->border_thickness;
+			box.width -= 2 * (deco_data.corner_radius + state->border_thickness);
 		}
 		scale_box(&box, output_scale);
 		render_rect(output, damage, &box, color);
@@ -860,10 +861,11 @@ static void render_top_border(struct sway_output *output,
 	box.y = floor(state->y);
 	box.width = state->width;
 	box.height = state->border_thickness;
+
 	// adjust sizing for rounded border corners
 	if (corner_radius) {
-		box.x += corner_radius;
-		box.width -= 2 * corner_radius;
+		box.x += corner_radius + state->border_thickness;
+		box.width -= 2 * (corner_radius + state->border_thickness);
 	}
 	scale_box(&box, output_scale);
 	render_rect(output, output_damage, &box, color);


### PR DESCRIPTION
The top and bottom borders were to wide which would intersect with the corners (especially with large borders)

Without:
![image](https://user-images.githubusercontent.com/35975961/210178902-9471ec9f-9e59-46d0-9244-f42e9042f34c.png)

With:
![image](https://user-images.githubusercontent.com/35975961/210178894-6dae882c-b3ac-4908-a682-80cfa07bcf86.png)
