### PR TITLE
Bumped version to 0.2

### DIFF
--- a/.github/workflows/fedora-build.yml
+++ b/.github/workflows/fedora-build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   fedora-build:
-    container: fedora:37
+    container: fedora:latest
     runs-on: ubuntu-latest
 
     steps:

--- a/build-scripts/aur-git/PKGBUILD
+++ b/build-scripts/aur-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Erik Reider <erik.reider@protonmail.com>
 _pkgname=swayfx
 pkgname="$_pkgname-git"
-pkgver=r6919.af282928
+pkgver=r6930.94ebb45e
 pkgrel=1
 license=("MIT")
 pkgdesc="SwayFX: Sway, but with eye candy!"

--- a/build-scripts/aur/PKGBUILD
+++ b/build-scripts/aur/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Erik Reider <erik.reider@protonmail.com>
 _pkgname=swayfx
 pkgname="$_pkgname"
-pkgver=0.1.1
+pkgver=0.2
 pkgrel=1
 license=("MIT")
 pkgdesc="SwayFX: Sway, but with eye candy!"
@@ -23,9 +23,9 @@ depends=(
 	"libxcb"
 	"libxkbcommon.so"
 	"pango"
-	"pcre"
+	"pcre2"
 	"ttf-font"
-	"wlroots0.15"
+	"wlroots<0.17"
 )
 optdepends=(
 	"alacritty: Terminal emulator used by the default config"

--- a/build-scripts/swayfx.rpkg.spec
+++ b/build-scripts/swayfx.rpkg.spec
@@ -4,7 +4,7 @@
 # Change to current Sway base version!
 %global SwayBaseVersion 1.8
 # Change to current SwayFX tag!
-%global Tag 0.1.1
+%global Tag 0.2
 
 Name:			{{{ git_dir_name }}}
 Version:		%{Tag}

--- a/build-scripts/swayfx.rpkg.spec
+++ b/build-scripts/swayfx.rpkg.spec
@@ -8,7 +8,7 @@
 
 Name:			{{{ git_dir_name }}}
 Version:		%{Tag}
-Release:		2%{?dist}
+Release:		3%{?dist}
 Summary:		SwayFX: Sway, but with eye candy!
 License:		MIT
 URL:			https://github.com/WillPower3309/swayfx
@@ -20,23 +20,25 @@ BuildRequires:	gnupg2
 BuildRequires:	meson >= 0.60.0
 BuildRequires:	pkgconfig(cairo)
 BuildRequires:	pkgconfig(gdk-pixbuf-2.0)
+BuildRequires:	pkgconfig(glesv2)
 BuildRequires:	pkgconfig(json-c) >= 0.13
 BuildRequires:	pkgconfig(libdrm)
 BuildRequires:	pkgconfig(libevdev)
 BuildRequires:	pkgconfig(libinput) >= 1.21.0
-BuildRequires:	pkgconfig(libpcre2)
+BuildRequires:	pkgconfig(libpcre2-8)
 BuildRequires:	pkgconfig(libsystemd) >= 239
 BuildRequires:	pkgconfig(libudev)
 BuildRequires:	pkgconfig(pango)
 BuildRequires:	pkgconfig(pangocairo)
+BuildRequires:	pkgconfig(pixman-1)
 BuildRequires:	pkgconfig(scdoc)
 BuildRequires:	pkgconfig(wayland-client)
 BuildRequires:	pkgconfig(wayland-cursor)
-BuildRequires:	pkgconfig(wayland-egl)
-BuildRequires:	pkgconfig(wayland-server) >= 1.20.0
+BuildRequires:	pkgconfig(wayland-server) >= 1.21.0
 BuildRequires:	pkgconfig(wayland-protocols) >= 1.24
 BuildRequires:	(pkgconfig(wlroots) >= 0.16.0 with pkgconfig(wlroots) < 0.17)
 BuildRequires:	pkgconfig(xcb)
+BuildRequires:	pkgconfig(xcb-icccm)
 BuildRequires:	pkgconfig(xkbcommon)
 # Dmenu is the default launcher in sway
 Recommends:		dmenu

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
 	'sway',
 	'c',
-	version: '0.1.1',
+	version: '0.2',
 	license: 'MIT',
 	meson_version: '>=0.60.0',
 	default_options: [


### PR DESCRIPTION
TODO for @WillPower3309:
- [x] Unselect Fedora 36 which doesn't ship wlroots 0.16

Note that this should be merged before tagging the 0.2 release :)