### PR TITLE
Hide separator between titlebar and content

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Sway is an incredible window manager, and certainly one of the most well establi
     - `dim_inactive_colors.unfocused <hex color> ex, #000000FF`
     - `dim_inactive_colors.urgent <hex color> ex, #900000FF`
 + Application saturation: `for_window [CRITERIA HERE] saturation <set|plus|minus> <val 0.0 <-> 2.0>`
++ Keep/remove separator border between titlebar and content: `titlebar_separator enable|disable`
 
 ## Roadmap
 

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -201,6 +201,7 @@ sway_cmd cmd_title_align;
 sway_cmd cmd_title_format;
 sway_cmd cmd_titlebar_border_thickness;
 sway_cmd cmd_titlebar_padding;
+sway_cmd cmd_titlebar_separator;
 sway_cmd cmd_unbindcode;
 sway_cmd cmd_unbindswitch;
 sway_cmd cmd_unbindgesture;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -487,6 +487,7 @@ struct sway_config {
 	bool shadows_on_csd_enabled;
 	int shadow_blur_sigma;
 	float shadow_color[4];
+	bool titlebar_separator;
 
 	char *swaynag_command;
 	struct swaynag_instance swaynag_config_errors;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -102,6 +102,7 @@ static const struct cmd_handler handlers[] = {
 	{ "title_align", cmd_title_align },
 	{ "titlebar_border_thickness", cmd_titlebar_border_thickness },
 	{ "titlebar_padding", cmd_titlebar_padding },
+	{ "titlebar_separator", cmd_titlebar_separator },
 	{ "unbindcode", cmd_unbindcode },
 	{ "unbindgesture", cmd_unbindgesture },
 	{ "unbindswitch", cmd_unbindswitch },

--- a/sway/commands/titlebar_separator.c
+++ b/sway/commands/titlebar_separator.c
@@ -1,0 +1,19 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/commands.h"
+#include "util.h"
+
+struct cmd_results *cmd_titlebar_separator(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "titlebar_separator", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	} else if(strcmp(argv[0], "disable") == 0) {
+		config->titlebar_separator = false;
+	} else if(strcmp(argv[0], "enable") == 0) {
+		config->titlebar_separator = true;
+	} else {
+		return cmd_results_new(CMD_FAILURE,
+				"Expected 'titlebar_separator enable|disable'");
+	}
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -343,6 +343,7 @@ static void config_defaults(struct sway_config *config) {
 	config->shadows_on_csd_enabled = false;
 	config->shadow_blur_sigma = 20.0f;
 	color_to_rgba(config->shadow_color, 0x0000007F);
+	config->titlebar_separator = true;
 
 	// The keysym to keycode translation
 	struct xkb_rule_names rules = {0};

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -631,6 +631,8 @@ static void render_titlebar(struct sway_output *output,
 	int titlebar_h_padding = config->titlebar_h_padding;
 	int titlebar_v_padding = config->titlebar_v_padding;
 	enum alignment title_align = config->title_align;
+	// value by which all heights should be adjusted to counteract removed bottom border
+	int bottom_border_compensation = config->titlebar_separator ? 0 : titlebar_border_thickness;
 
 	if (corner_location == NONE) {
 		corner_radius = 0;
@@ -660,18 +662,20 @@ static void render_titlebar(struct sway_output *output,
 	render_rect(output, output_damage, &box, color);
 
 	// Single pixel bar below title
-	box.x = x;
-	box.y = y + container_titlebar_height() - titlebar_border_thickness;
-	box.width = width;
-	box.height = titlebar_border_thickness;
-	scale_box(&box, output_scale);
-	render_rect(output, output_damage, &box, color);
+	if (config->titlebar_separator) {
+		box.x = x;
+		box.y = y + container_titlebar_height() - titlebar_border_thickness;
+		box.width = width;
+		box.height = titlebar_border_thickness;
+		scale_box(&box, output_scale);
+		render_rect(output, output_damage, &box, color);
+	}
 
 	// Single pixel bar left edge
 	box.x = x;
 	box.y = y;
 	box.width = titlebar_border_thickness;
-	box.height = container_titlebar_height() - titlebar_border_thickness;
+	box.height = container_titlebar_height() + bottom_border_compensation;
 	if (corner_radius && corner_location != TOP_RIGHT) {
 		box.height -= corner_radius;
 		box.y += corner_radius;
@@ -683,7 +687,7 @@ static void render_titlebar(struct sway_output *output,
 	box.x = x + width - titlebar_border_thickness;
 	box.y = y;
 	box.width = titlebar_border_thickness;
-	box.height = container_titlebar_height() - titlebar_border_thickness;
+	box.height = container_titlebar_height() + bottom_border_compensation;
 	if (corner_radius && corner_location != TOP_LEFT) {
 		box.height -= corner_radius;
 		box.y += corner_radius;
@@ -781,7 +785,7 @@ static void render_titlebar(struct sway_output *output,
 
 		// Padding below
 		box.y += ob_padding_above + texture_box.height;
-		box.height = ob_padding_below;
+		box.height = ob_padding_below + bottom_border_compensation;
 		render_rect(output, output_damage, &box, color);
 	}
 
@@ -857,7 +861,7 @@ static void render_titlebar(struct sway_output *output,
 
 		// Padding below
 		box.y += ob_padding_above + texture_box.height;
-		box.height = ob_padding_below;
+		box.height = ob_padding_below + bottom_border_compensation;
 		render_rect(output, output_damage, &box, color);
 	}
 
@@ -891,7 +895,7 @@ static void render_titlebar(struct sway_output *output,
 	if (box.width > 0) {
 		box.x = ob_left_x + ob_left_width + round(output_x * output_scale);
 		box.y = round(bg_y * output_scale);
-		box.height = ob_bg_height;
+		box.height = ob_bg_height + bottom_border_compensation;
 		render_rect(output, output_damage, &box, color);
 	}
 
@@ -900,7 +904,7 @@ static void render_titlebar(struct sway_output *output,
 	box.y = y + titlebar_border_thickness;
 	box.width = titlebar_h_padding - titlebar_border_thickness;
 	box.height = (titlebar_v_padding - titlebar_border_thickness) * 2 +
-		config->font_height;
+		config->font_height + bottom_border_compensation;
 	scale_box(&box, output_scale);
 	int left_x = ob_left_x + round(output_x * output_scale);
 	if (box.x + box.width < left_x) {
@@ -917,7 +921,7 @@ static void render_titlebar(struct sway_output *output,
 	box.y = y + titlebar_border_thickness;
 	box.width = titlebar_h_padding - titlebar_border_thickness;
 	box.height = (titlebar_v_padding - titlebar_border_thickness) * 2 +
-		config->font_height;
+		config->font_height + bottom_border_compensation;
 	scale_box(&box, output_scale);
 	int right_rx = ob_right_x + ob_right_width + round(output_x * output_scale);
 	if (right_rx < box.x) {

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -108,6 +108,7 @@ sway_sources = files(
 	'commands/seat/pointer_constraint.c',
 	'commands/seat/shortcuts_inhibitor.c',
 	'commands/seat/xcursor_theme.c',
+	'commands/titlebar_separator.c',
 	'commands/set.c',
 	'commands/shadow_blur_radius.c',
 	'commands/shadow_color.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -761,6 +761,9 @@ The default colors are:
 	to be greater than the _horizontal_ or _vertical_ value, the value will be
 	treated as that of _corner_radius_.
 
+*titlebar_separator* enable|disable
+	Allows to remove the border between titlebar and window content.
+
 *for_window* <criteria> <command>
 	Whenever a window that matches _criteria_ appears, run list of commands.
 	See *CRITERIA* for more details.


### PR DESCRIPTION
Solves #70.
Toggled via titlebar_separator enable|disable, where disable hides the border.

![image](https://user-images.githubusercontent.com/49650767/211620530-b59d3505-57e5-41b7-b049-a1e3c0fcc773.png)
