### PR TITLE
chore: update flake to base on nixpkgs sway-1.8

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668531822,
-        "narHash": "sha256-rNt2SphDCQTbAgWBX9ZCMIn5ISxeb0l6b6kRLvzbFVo=",
+        "lastModified": 1673947312,
+        "narHash": "sha256-xx/2nRwRy3bXrtry6TtydKpJpqHahjuDB5sFkQ/XNDE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "97b8d9459f7922ce0e666113a1e8e6071424ae16",
+        "rev": "2d38b664b4400335086a713a0036aafaa002c003",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR fixes the build of the nix flake, apparently broken by the 1.8 rebase.

I updated the inputs so that the nixpkgs used contains [1] in order to provide correct build dependencies, e.g. pcre2.

[1] https://github.com/NixOS/nixpkgs/commit/9896c8830321c1ec6e1e6b5232c0e023db8d2fb7