### PR TITLE
feat: smart smart_corner_radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Sway is an incredible window manager, and certainly one of the most well establi
 ## New Configuration Options
 
 + Corner radius: `corner_radius <val>`
++ Smart corner radius: `smart_corner_radius on|off`
 + Application saturation: `for_window [CRITERIA HERE] saturation <set|plus|minus> <val 0.0 <-> 2.0>`
 + Window shadows: *ONLY ON SWAYFX-GIT, NOT YET RELEASED*
     - `shadows on|off`

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -183,6 +183,7 @@ sway_cmd cmd_shadow_color;
 sway_cmd cmd_shadows;
 sway_cmd cmd_show_marks;
 sway_cmd cmd_smart_borders;
+sway_cmd cmd_smart_corner_radius;
 sway_cmd cmd_smart_gaps;
 sway_cmd cmd_split;
 sway_cmd cmd_splith;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -476,6 +476,7 @@ enum xwayland_mode {
 struct sway_config {
 	// SwayFX config options
 	int corner_radius;
+	bool smart_corner_radius;
 	float dim_inactive;
 	// dim_inactive colors
 	struct {

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -93,6 +93,7 @@ static const struct cmd_handler handlers[] = {
 	{ "shadows", cmd_shadows },
 	{ "show_marks", cmd_show_marks },
 	{ "smart_borders", cmd_smart_borders },
+	{ "smart_corner_radius", cmd_smart_corner_radius },
 	{ "smart_gaps", cmd_smart_gaps },
 	{ "tiling_drag", cmd_tiling_drag },
 	{ "tiling_drag_threshold", cmd_tiling_drag_threshold },

--- a/sway/commands/smart_corner_radius.c
+++ b/sway/commands/smart_corner_radius.c
@@ -1,0 +1,17 @@
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/tree/arrange.h"
+#include "util.h"
+
+struct cmd_results *cmd_smart_corner_radius(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "smart_corner_radius", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	config->smart_corner_radius = parse_boolean(argv[0], true);
+
+	arrange_root();
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -335,6 +335,7 @@ static void config_defaults(struct sway_config *config) {
 
 	// SwayFX defaults
 	config->corner_radius = 0;
+	config->smart_corner_radius = true;
 	config->dim_inactive = 0.0f;
 	color_to_rgba(config->dim_inactive_colors.unfocused, 0x000000FF);
 	color_to_rgba(config->dim_inactive_colors.urgent, 0x900000FF);

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1003,6 +1003,9 @@ static void render_containers_linear(struct sway_output *output,
 			}
 
 			bool has_titlebar = state->border == B_NORMAL;
+			int corner_radius = config->smart_corner_radius &&
+					output->current.active_workspace->current_gaps.top == 0
+					? 0 : child->corner_radius;
 			struct decoration_data deco_data = {
 				.alpha = child->alpha,
 				.dim_color = view_is_urgent(view)
@@ -1010,8 +1013,7 @@ static void render_containers_linear(struct sway_output *output,
 								 : config->dim_inactive_colors.unfocused,
 				.dim = child->current.focused ? 0.0f: config->dim_inactive,
 				// no corner radius if no gaps (allows smart_gaps to work as expected)
-				.corner_radius = output->current.active_workspace->current_gaps.top == 0
-					? 0 : child->corner_radius,
+				.corner_radius = corner_radius,
 				.saturation = child->saturation,
 				.has_titlebar = has_titlebar,
 			};

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -49,6 +49,7 @@ sway_sources = files(
 	'commands/border.c',
 	'commands/client.c',
 	'commands/corner_radius.c',
+	'commands/smart_corner_radius.c',
 	'commands/create_output.c',
 	'commands/default_border.c',
 	'commands/default_floating_border.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -649,6 +649,9 @@ The default colors are:
 *corner_radius* <radius>
 	Set corner radius for new windows.
 
+*smart_corner_radius* on|off
+	Set corner radius only if there are gaps around the window.
+
 *dim_inactive* <value>
 	Adjusts the dimming of inactive windows between 0.0 (no dimming) and 1.0
 	(fully dimmed) while 0.0 is the default value.


### PR DESCRIPTION
This PR adds a `smart_corner_radius` feature.

With this commit https://github.com/WillPower3309/swayfx/commit/a6f60eeb31c341819611da9f844d4687b3160706 rounded corners on windows reaching to the very border of the screen are not possible anymore.

I think this behavior should be configurable. Rounded corners on windows reaching to the screen borders can create a beautiful appearance as well.

As this feature shares some behavior with `smart_gaps` and `smart_borders`, I thought `smart_corner_radius` could be an appropriate name.

Hope you like this tiny addition.
Thanks a lot for creating SwayFX!