### PR TITLE
fix: dim color on focus parent

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1008,7 +1008,7 @@ static void render_containers_linear(struct sway_output *output,
 				.dim_color = view_is_urgent(view)
 								 ? config->dim_inactive_colors.urgent
 								 : config->dim_inactive_colors.unfocused,
-				.dim = child->current.focused ? 0.0f: config->dim_inactive,
+				.dim = child->current.focused || parent->focused ? 0.0f: config->dim_inactive,
 				// no corner radius if no gaps (allows smart_gaps to work as expected)
 				.corner_radius = output->current.active_workspace->current_gaps.top == 0
 					? 0 : child->corner_radius,


### PR DESCRIPTION
This PR fixes a minor glitch where dim color for unfocused windows applied also for windows that have their parent selected.

With this fix, windows being focused, and windows having a focused parent do not receive the dim color anymore and therefor now behave the same way as focused/unfocused border colors.