### PR TITLE
Add option for enabling shadows for CSD windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Sway is an incredible window manager, and certainly one of the most well establi
 + Application saturation: `for_window [CRITERIA HERE] saturation <set|plus|minus> <val 0.0 <-> 2.0>`
 + Window shadows: *ONLY ON SWAYFX-GIT, NOT YET RELEASED*
     - `shadows on|off`
+    - `shadows_on_csd on|off` (**Note**: The shadow might not fit some windows)
     - `shadow_blur_radius <integer value 0 - 100>`
     - `shadow_color <hex color with alpha> ex, #0000007F`
 + Dim unfocused windows:

--- a/config.in
+++ b/config.in
@@ -25,6 +25,7 @@ set $menu dmenu_path | dmenu | xargs swaymsg exec --
 corner_radius 10
 
 shadows off
+shadows_on_csd off
 shadow_blur_radius 20
 shadow_color #0000007F
 

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -181,6 +181,7 @@ sway_cmd cmd_shortcuts_inhibitor;
 sway_cmd cmd_shadow_blur_radius;
 sway_cmd cmd_shadow_color;
 sway_cmd cmd_shadows;
+sway_cmd cmd_shadows_on_csd;
 sway_cmd cmd_show_marks;
 sway_cmd cmd_smart_borders;
 sway_cmd cmd_smart_corner_radius;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -484,6 +484,7 @@ struct sway_config {
 		float urgent[4];
 	} dim_inactive_colors;
 	bool shadow_enabled;
+	bool shadows_on_csd_enabled;
 	int shadow_blur_sigma;
 	float shadow_color[4];
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -91,6 +91,7 @@ static const struct cmd_handler handlers[] = {
 	{ "shadow_blur_radius", cmd_shadow_blur_radius },
 	{ "shadow_color", cmd_shadow_color },
 	{ "shadows", cmd_shadows },
+	{ "shadows_on_csd", cmd_shadows_on_csd },
 	{ "show_marks", cmd_show_marks },
 	{ "smart_borders", cmd_smart_borders },
 	{ "smart_corner_radius", cmd_smart_corner_radius },

--- a/sway/commands/shadows_on_csd.c
+++ b/sway/commands/shadows_on_csd.c
@@ -1,0 +1,23 @@
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/tree/arrange.h"
+#include "sway/tree/view.h"
+#include "sway/tree/container.h"
+#include "log.h"
+#include "stringop.h"
+#include "util.h"
+
+struct cmd_results *cmd_shadows_on_csd(int argc, char **argv) {
+	struct cmd_results *error = checkarg(argc, "shadows_on_csd", EXPECTED_AT_LEAST, 1);
+
+	if (error) {
+		return error;
+	}
+
+	config->shadows_on_csd_enabled = parse_boolean(argv[0], config->shadows_on_csd_enabled);
+
+	arrange_root();
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -340,6 +340,7 @@ static void config_defaults(struct sway_config *config) {
 	color_to_rgba(config->dim_inactive_colors.unfocused, 0x000000FF);
 	color_to_rgba(config->dim_inactive_colors.urgent, 0x900000FF);
 	config->shadow_enabled = false;
+	config->shadows_on_csd_enabled = false;
 	config->shadow_blur_sigma = 20.0f;
 	color_to_rgba(config->shadow_color, 0x0000007F);
 

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -489,8 +489,8 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 		render_view_toplevels(view, output, damage, deco_data);
 	}
 
-	// if CSD borders, don't render borders or shadow
-	if (con->current.border == B_CSD) {
+	// Only draw shadows on CSD windows if shadows_on_csd is enabled
+	if (con->current.border == B_CSD && !config->shadows_on_csd_enabled) {
 		return;
 	}
 

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -504,7 +504,7 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 			state->border_thickness);
 	}
 
-	if (con->current.border == B_NONE) {
+	if (con->current.border == B_NONE || con->current.border == B_CSD) {
 		return;
 	}
 

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -110,6 +110,7 @@ sway_sources = files(
 	'commands/shadow_blur_radius.c',
 	'commands/shadow_color.c',
 	'commands/shadows.c',
+	'commands/shadows_on_csd.c',
 	'commands/show_marks.c',
 	'commands/shortcuts_inhibitor.c',
 	'commands/smart_borders.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -666,6 +666,10 @@ The default colors are:
 	Adjusts if shadows should be enabled or not (on|off). Can also be set per
 	window with *for_window*.
 
+*shadows_on_csd* <value>
+	Adjusts if shadows should be drawn on windows that draw their own
+	decorations (on|off). *Note:* The shadow might not fit some windows.
+
 *shadow_blur_radius* <value>
 	Adjusts the shadow blur radius of windows between 0 (disabled) and 100
 	while 20 is the default value.


### PR DESCRIPTION
Enables shadows to be rendered on windows with CSD.

#94 removes CSD elements outside of the window bounds, so no worries about drawing double shadows