### PR TITLE
fix: no dim on parent select in tabbed and stacked

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1112,7 +1112,7 @@ static void render_containers_tabbed(struct sway_output *output,
 			.dim_color = view_is_urgent(current->view)
 							 ? config->dim_inactive_colors.urgent
 							 : config->dim_inactive_colors.unfocused,
-			.dim = current->current.focused ? 0.0f: config->dim_inactive,
+			.dim = current->current.focused || parent->focused ? 0.0f: config->dim_inactive,
 			.corner_radius = current->corner_radius,
 			.saturation = current->saturation,
 			.has_titlebar = true,
@@ -1186,7 +1186,7 @@ static void render_containers_stacked(struct sway_output *output,
 			.dim_color = view_is_urgent(current->view)
 							 ? config->dim_inactive_colors.urgent
 							 : config->dim_inactive_colors.unfocused,
-			.dim = current->current.focused ? 0.0f: config->dim_inactive,
+			.dim = current->current.focused || parent->focused ? 0.0f: config->dim_inactive,
 			.saturation = current->saturation,
 			.corner_radius = current->corner_radius,
 			.has_titlebar = true,


### PR DESCRIPTION
When running `focus parent` on a window that is part of a stacked or tabbed container, the window will be dimmed, even though the window is still selected (together with its parent and siblings).

My recent PR #102 fixed window dim only in horizontal and vertical layout. But the same issue appears in tabbed and stacked layouts. This PR fixes it.
