### PR TITLE
Fix: rotated outputs

### DIFF
--- a/include/sway/desktop/fx_renderer/fx_renderer.h
+++ b/include/sway/desktop/fx_renderer/fx_renderer.h
@@ -9,7 +9,7 @@
 #include "sway/desktop/fx_renderer/fx_framebuffer.h"
 #include "sway/desktop/fx_renderer/fx_texture.h"
 
-enum corner_location { ALL, TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT, NONE };
+enum corner_location { TOP_LEFT, TOP_RIGHT, BOTTOM_RIGHT, BOTTOM_LEFT, ALL, NONE };
 
 enum fx_tex_shader_source {
 	SHADER_SOURCE_TEXTURE_RGBA = 1,

--- a/include/sway/desktop/fx_renderer/fx_renderer.h
+++ b/include/sway/desktop/fx_renderer/fx_renderer.h
@@ -164,19 +164,17 @@ bool fx_render_texture_with_matrix(struct fx_renderer *renderer, struct fx_textu
 void fx_render_rect(struct fx_renderer *renderer, const struct wlr_box *box,
 		const float color[static 4], const float projection[static 9]);
 
-void fx_render_rounded_rect(struct fx_renderer *renderer, struct wlr_output *output,
-		const struct wlr_box *box, const float color[static 4],
-		const float projection[static 9], int radius,
+void fx_render_rounded_rect(struct fx_renderer *renderer, const struct wlr_box *box,
+		const float color[static 4], const float matrix[static 9], int radius,
 		enum corner_location corner_location);
 
-void fx_render_border_corner(struct fx_renderer *renderer, struct wlr_output *output,
-		const struct wlr_box *box, const float color[static 4],
-		const float projection[static 9], enum corner_location corner_location,
-		int radius, int border_thickness);
+void fx_render_border_corner(struct fx_renderer *renderer, const struct wlr_box *box,
+		const float color[static 4], const float matrix[static 9],
+		enum corner_location corner_location, int radius, int border_thickness);
 
-void fx_render_box_shadow(struct fx_renderer *renderer, struct wlr_output *output,
-		const struct wlr_box *box, const float color[static 4],
-		const float projection[static 9], int radius, float blur_sigma);
+void fx_render_box_shadow(struct fx_renderer *renderer, const struct wlr_box *box,
+		const float color[static 4], const float matrix[static 9], int radius,
+		float blur_sigma);
 
 void fx_render_blur(struct fx_renderer *renderer, const float matrix[static 9],
 		struct fx_framebuffer **buffer, struct blur_shader *shader, const struct wlr_box *box,

--- a/include/sway/desktop/fx_renderer/fx_renderer.h
+++ b/include/sway/desktop/fx_renderer/fx_renderer.h
@@ -164,16 +164,19 @@ bool fx_render_texture_with_matrix(struct fx_renderer *renderer, struct fx_textu
 void fx_render_rect(struct fx_renderer *renderer, const struct wlr_box *box,
 		const float color[static 4], const float projection[static 9]);
 
-void fx_render_rounded_rect(struct fx_renderer *renderer, const struct wlr_box *box,
-		const float color[static 4], const float projection[static 9],
-		int radius, enum corner_location corner_location);
+void fx_render_rounded_rect(struct fx_renderer *renderer, struct wlr_output *output,
+		const struct wlr_box *box, const float color[static 4],
+		const float projection[static 9], int radius,
+		enum corner_location corner_location);
 
-void fx_render_border_corner(struct fx_renderer *renderer, const struct wlr_box *box,
-		const float color[static 4], const float projection[static 9],
-		enum corner_location corner_location, int radius, int border_thickness);
+void fx_render_border_corner(struct fx_renderer *renderer, struct wlr_output *output,
+		const struct wlr_box *box, const float color[static 4],
+		const float projection[static 9], enum corner_location corner_location,
+		int radius, int border_thickness);
 
-void fx_render_box_shadow(struct fx_renderer *renderer, const struct wlr_box *box,
-		const float color[static 4], const float projection[static 9], int radius, float blur_sigma);
+void fx_render_box_shadow(struct fx_renderer *renderer, struct wlr_output *output,
+		const struct wlr_box *box, const float color[static 4],
+		const float projection[static 9], int radius, float blur_sigma);
 
 void fx_render_blur(struct fx_renderer *renderer, const float matrix[static 9],
 		struct fx_framebuffer **buffer, struct blur_shader *shader, const struct wlr_box *box,

--- a/include/sway/desktop/fx_renderer/fx_renderer.h
+++ b/include/sway/desktop/fx_renderer/fx_renderer.h
@@ -21,6 +21,8 @@ enum fx_rounded_quad_shader_source {
 	SHADER_SOURCE_QUAD_ROUND = 1,
 	SHADER_SOURCE_QUAD_ROUND_TOP_LEFT = 2,
 	SHADER_SOURCE_QUAD_ROUND_TOP_RIGHT = 3,
+	SHADER_SOURCE_QUAD_ROUND_BOTTOM_RIGHT = 4,
+	SHADER_SOURCE_QUAD_ROUND_BOTTOM_LEFT = 5,
 };
 
 struct decoration_data {
@@ -106,6 +108,8 @@ struct fx_renderer {
 		struct rounded_quad_shader rounded_quad;
 		struct rounded_quad_shader rounded_tl_quad;
 		struct rounded_quad_shader rounded_tr_quad;
+		struct rounded_quad_shader rounded_bl_quad;
+		struct rounded_quad_shader rounded_br_quad;
 
 		struct blur_shader blur1;
 		struct blur_shader blur2;

--- a/sway/desktop/fx_renderer/fx_framebuffer.c
+++ b/sway/desktop/fx_renderer/fx_framebuffer.c
@@ -1,3 +1,4 @@
+#include <wlr/util/box.h>
 #include "log.h"
 #include "sway/desktop/fx_renderer/fx_framebuffer.h"
 
@@ -26,15 +27,16 @@ void fx_framebuffer_create(struct fx_framebuffer *buffer, int width, int height,
 
 	if (firstAlloc || buffer->texture.width != width || buffer->texture.height != height) {
 		glBindTexture(GL_TEXTURE_2D, buffer->texture.id);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA,
+				monitor_box.width, monitor_box.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
 
 		glBindFramebuffer(GL_FRAMEBUFFER, buffer->fb);
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
 				buffer->texture.id, 0);
 		buffer->texture.target = GL_TEXTURE_2D;
 		buffer->texture.has_alpha = false;
-		buffer->texture.width = width;
-		buffer->texture.height = height;
+		buffer->texture.width = monitor_box.width;
+		buffer->texture.height = monitor_box.height;
 
 		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
 		if (status != GL_FRAMEBUFFER_COMPLETE) {

--- a/sway/desktop/fx_renderer/fx_framebuffer.c
+++ b/sway/desktop/fx_renderer/fx_framebuffer.c
@@ -27,16 +27,15 @@ void fx_framebuffer_create(struct fx_framebuffer *buffer, int width, int height,
 
 	if (firstAlloc || buffer->texture.width != width || buffer->texture.height != height) {
 		glBindTexture(GL_TEXTURE_2D, buffer->texture.id);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA,
-				monitor_box.width, monitor_box.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
 
 		glBindFramebuffer(GL_FRAMEBUFFER, buffer->fb);
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
 				buffer->texture.id, 0);
 		buffer->texture.target = GL_TEXTURE_2D;
 		buffer->texture.has_alpha = false;
-		buffer->texture.width = monitor_box.width;
-		buffer->texture.height = monitor_box.height;
+		buffer->texture.width = width;
+		buffer->texture.height = height;
 
 		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
 		if (status != GL_FRAMEBUFFER_COMPLETE) {

--- a/sway/desktop/fx_renderer/fx_framebuffer.c
+++ b/sway/desktop/fx_renderer/fx_framebuffer.c
@@ -1,4 +1,3 @@
-#include <wlr/util/box.h>
 #include "log.h"
 #include "sway/desktop/fx_renderer/fx_framebuffer.h"
 

--- a/sway/desktop/fx_renderer/fx_renderer.c
+++ b/sway/desktop/fx_renderer/fx_renderer.c
@@ -257,6 +257,14 @@ struct fx_renderer *fx_renderer_create(struct wlr_egl *egl) {
 			SHADER_SOURCE_QUAD_ROUND_TOP_RIGHT)) {
 		goto error;
 	}
+	if (!link_rounded_quad_program(renderer, &renderer->shaders.rounded_bl_quad,
+			SHADER_SOURCE_QUAD_ROUND_BOTTOM_LEFT)) {
+		goto error;
+	}
+	if (!link_rounded_quad_program(renderer, &renderer->shaders.rounded_br_quad,
+			SHADER_SOURCE_QUAD_ROUND_BOTTOM_RIGHT)) {
+		goto error;
+	}
 
 	// Border corner shader
 	prog = link_program(corner_frag_src);
@@ -345,6 +353,8 @@ error:
 	glDeleteProgram(renderer->shaders.rounded_quad.program);
 	glDeleteProgram(renderer->shaders.rounded_tl_quad.program);
 	glDeleteProgram(renderer->shaders.rounded_tr_quad.program);
+	glDeleteProgram(renderer->shaders.rounded_bl_quad.program);
+	glDeleteProgram(renderer->shaders.rounded_br_quad.program);
 	glDeleteProgram(renderer->shaders.corner.program);
 	glDeleteProgram(renderer->shaders.box_shadow.program);
 	glDeleteProgram(renderer->shaders.blur1.program);
@@ -587,12 +597,10 @@ void fx_render_rounded_rect(struct fx_renderer *renderer, const struct wlr_box *
 			shader = &renderer->shaders.rounded_tr_quad;
 			break;
 		case BOTTOM_LEFT:
-			// TODO
-			shader = &renderer->shaders.rounded_quad;
+			shader = &renderer->shaders.rounded_bl_quad;
 			break;
 		case BOTTOM_RIGHT:
-			// TODO
-			shader = &renderer->shaders.rounded_quad;
+			shader = &renderer->shaders.rounded_br_quad;
 			break;
 		default:
 			sway_log(SWAY_ERROR, "Invalid Corner Location. Aborting render");

--- a/sway/desktop/fx_renderer/fx_renderer.c
+++ b/sway/desktop/fx_renderer/fx_renderer.c
@@ -10,6 +10,7 @@
 #include <wlr/render/egl.h>
 #include <wlr/render/gles2.h>
 #include <wlr/types/wlr_matrix.h>
+#include <wlr/types/wlr_output.h>
 #include <wlr/util/box.h>
 
 #include "log.h"
@@ -477,10 +478,16 @@ bool fx_render_subtexture_with_matrix(struct fx_renderer *renderer, struct fx_te
 
 	float* dim_color = deco_data.dim_color;
 
+	struct wlr_box transformed_box;
+	int width, height;
+	wlr_output_transformed_resolution(wlr_output, &width, &height);
+	wlr_box_transform(&transformed_box, dst_box,
+			wlr_output_transform_invert(wlr_output->transform), width, height);
+
 	glUniformMatrix3fv(shader->proj, 1, GL_FALSE, gl_matrix);
 	glUniform1i(shader->tex, 0);
-	glUniform2f(shader->size, dst_box->width, dst_box->height);
-	glUniform2f(shader->position, dst_box->x, dst_box->y);
+	glUniform2f(shader->size, transformed_box.width, transformed_box.height);
+	glUniform2f(shader->position, transformed_box.x, transformed_box.y);
 	glUniform1f(shader->alpha, deco_data.alpha);
 	glUniform1f(shader->dim, deco_data.dim);
 	glUniform4f(shader->dim_color, dim_color[0], dim_color[1], dim_color[2], dim_color[3]);
@@ -566,9 +573,10 @@ void fx_render_rect(struct fx_renderer *renderer, const struct wlr_box *box,
 	glDisableVertexAttribArray(renderer->shaders.quad.pos_attrib);
 }
 
-void fx_render_rounded_rect(struct fx_renderer *renderer, const struct wlr_box *box,
-		const float color[static 4], const float projection[static 9],
-		int radius, enum corner_location corner_location) {
+void fx_render_rounded_rect(struct fx_renderer *renderer, struct wlr_output *output, 
+		const struct wlr_box *box, const float color[static 4],
+		const float projection[static 9], int radius,
+		enum corner_location corner_location) {
 	if (box->width == 0 || box->height == 0) {
 		return;
 	}
@@ -602,6 +610,12 @@ void fx_render_rounded_rect(struct fx_renderer *renderer, const struct wlr_box *
 
 	wlr_matrix_transpose(gl_matrix, gl_matrix);
 
+	struct wlr_box transformed_box;
+	int width, height;
+	wlr_output_transformed_resolution(output, &width, &height);
+	wlr_box_transform(&transformed_box, box,
+			wlr_output_transform_invert(output->transform), width, height);
+
 	glEnable(GL_BLEND);
 
 	glUseProgram(shader->program);
@@ -610,8 +624,8 @@ void fx_render_rounded_rect(struct fx_renderer *renderer, const struct wlr_box *
 	glUniform4f(shader->color, color[0], color[1], color[2], color[3]);
 
 	// rounded corners
-	glUniform2f(shader->size, box->width, box->height);
-	glUniform2f(shader->position, box->x, box->y);
+	glUniform2f(shader->size, transformed_box.width, transformed_box.height);
+	glUniform2f(shader->position, transformed_box.x, transformed_box.y);
 	glUniform1f(shader->radius, radius);
 
 	glVertexAttribPointer(shader->pos_attrib, 2, GL_FLOAT, GL_FALSE,
@@ -624,9 +638,10 @@ void fx_render_rounded_rect(struct fx_renderer *renderer, const struct wlr_box *
 	glDisableVertexAttribArray(shader->pos_attrib);
 }
 
-void fx_render_border_corner(struct fx_renderer *renderer, const struct wlr_box *box,
-		const float color[static 4], const float projection[static 9],
-		enum corner_location corner_location, int radius, int border_thickness) {
+void fx_render_border_corner(struct fx_renderer *renderer, struct wlr_output *output,
+		const struct wlr_box *box, const float color[static 4],
+		const float projection[static 9], enum corner_location corner_location,
+		int radius, int border_thickness) {
 	if (border_thickness == 0 || box->width == 0 || box->height == 0) {
 		return;
 	}
@@ -641,6 +656,12 @@ void fx_render_border_corner(struct fx_renderer *renderer, const struct wlr_box 
 	// wlr_matrix_multiply(gl_matrix, flip_180, gl_matrix);
 
 	wlr_matrix_transpose(gl_matrix, gl_matrix);
+
+	struct wlr_box transformed_box;
+	int width, height;
+	wlr_output_transformed_resolution(output, &width, &height);
+	wlr_box_transform(&transformed_box, box,
+			wlr_output_transform_invert(output->transform), width, height);
 
 	if (color[3] == 1.0 && !radius) {
 		glDisable(GL_BLEND);
@@ -658,9 +679,9 @@ void fx_render_border_corner(struct fx_renderer *renderer, const struct wlr_box 
 	glUniform1f(renderer->shaders.corner.is_bottom_left, corner_location == BOTTOM_LEFT);
 	glUniform1f(renderer->shaders.corner.is_bottom_right, corner_location == BOTTOM_RIGHT);
 
-	glUniform2f(renderer->shaders.corner.position, box->x, box->y);
+	glUniform2f(renderer->shaders.corner.position, transformed_box.x, transformed_box.y);
 	glUniform1f(renderer->shaders.corner.radius, radius);
-	glUniform2f(renderer->shaders.corner.half_size, box->width / 2.0, box->height / 2.0);
+	glUniform2f(renderer->shaders.corner.half_size, transformed_box.width / 2.0, transformed_box.height / 2.0);
 	glUniform1f(renderer->shaders.corner.half_thickness, border_thickness / 2.0);
 
 	glVertexAttribPointer(renderer->shaders.corner.pos_attrib, 2, GL_FLOAT, GL_FALSE,
@@ -674,9 +695,9 @@ void fx_render_border_corner(struct fx_renderer *renderer, const struct wlr_box 
 }
 
 // TODO: alpha input arg?
-void fx_render_box_shadow(struct fx_renderer *renderer, const struct wlr_box *box,
-		const float color[static 4], const float projection[static 9],
-		int corner_radius, float blur_sigma) {
+void fx_render_box_shadow(struct fx_renderer *renderer, struct wlr_output *output,
+		const struct wlr_box *box, const float color[static 4],
+		const float projection[static 9], int corner_radius, float blur_sigma) {
 	if (box->width == 0 || box->height == 0) {
 		return;
 	}
@@ -691,6 +712,12 @@ void fx_render_box_shadow(struct fx_renderer *renderer, const struct wlr_box *bo
 	// wlr_matrix_multiply(gl_matrix, flip_180, gl_matrix);
 
 	wlr_matrix_transpose(gl_matrix, gl_matrix);
+
+	struct wlr_box transformed_box;
+	int width, height;
+	wlr_output_transformed_resolution(output, &width, &height);
+	wlr_box_transform(&transformed_box, box,
+			wlr_output_transform_invert(output->transform), width, height);
 
 	// Init stencil work
 	// NOTE: Alpha needs to be set to 1.0 to be able to discard any "empty" pixels
@@ -711,7 +738,7 @@ void fx_render_box_shadow(struct fx_renderer *renderer, const struct wlr_box *bo
 	// Disable writing to color buffer
 	glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 	// Draw the rounded rect as a mask
-	fx_render_rounded_rect(renderer, &inner_box, col, projection, corner_radius, ALL);
+	fx_render_rounded_rect(renderer, output, &inner_box, col, projection, corner_radius, ALL);
 	// Close the mask
 	glStencilFunc(GL_NOTEQUAL, 1, 0xFF);
 	glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
@@ -731,8 +758,8 @@ void fx_render_box_shadow(struct fx_renderer *renderer, const struct wlr_box *bo
 	glUniform1f(renderer->shaders.box_shadow.blur_sigma, blur_sigma);
 	glUniform1f(renderer->shaders.box_shadow.corner_radius, corner_radius);
 
-	glUniform2f(renderer->shaders.box_shadow.size, box->width, box->height);
-	glUniform2f(renderer->shaders.box_shadow.position, box->x, box->y);
+	glUniform2f(renderer->shaders.box_shadow.size, transformed_box.width, transformed_box.height);
+	glUniform2f(renderer->shaders.box_shadow.position, transformed_box.x, transformed_box.y);
 
 	glVertexAttribPointer(renderer->shaders.box_shadow.pos_attrib, 2, GL_FLOAT, GL_FALSE,
 			0, verts);

--- a/sway/desktop/fx_renderer/fx_renderer.c
+++ b/sway/desktop/fx_renderer/fx_renderer.c
@@ -41,7 +41,7 @@ static void create_stencil_buffer(GLuint *buffer_id, int width, int height) {
 
 	glGenRenderbuffers(1, buffer_id);
 	glBindRenderbuffer(GL_RENDERBUFFER, *buffer_id);
-	glRenderbufferStorage(GL_RENDERBUFFER, GL_STENCIL_INDEX8, monitor_box.width, monitor_box.height);
+	glRenderbufferStorage(GL_RENDERBUFFER, GL_STENCIL_INDEX8, width, height);
 	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, *buffer_id);
 	GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
 	if (status != GL_FRAMEBUFFER_COMPLETE) {
@@ -404,7 +404,7 @@ void fx_renderer_begin(struct fx_renderer *renderer, int width, int height) {
 	create_stencil_buffer(&renderer->stencil_buffer_id, width, height);
 
 	// refresh projection matrix
-	matrix_projection(renderer->projection, monitor_box.width, monitor_box.height,
+	matrix_projection(renderer->projection, width, height,
 		WL_OUTPUT_TRANSFORM_FLIPPED_180);
 
 	glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);

--- a/sway/desktop/fx_renderer/fx_renderer.c
+++ b/sway/desktop/fx_renderer/fx_renderer.c
@@ -586,6 +586,14 @@ void fx_render_rounded_rect(struct fx_renderer *renderer, const struct wlr_box *
 		case TOP_RIGHT:
 			shader = &renderer->shaders.rounded_tr_quad;
 			break;
+		case BOTTOM_LEFT:
+			// TODO
+			shader = &renderer->shaders.rounded_quad;
+			break;
+		case BOTTOM_RIGHT:
+			// TODO
+			shader = &renderer->shaders.rounded_quad;
+			break;
 		default:
 			sway_log(SWAY_ERROR, "Invalid Corner Location. Aborting render");
 			abort();
@@ -629,8 +637,6 @@ void fx_render_border_corner(struct fx_renderer *renderer, const struct wlr_box 
 	}
 	assert(box->width > 0 && box->height > 0);
 
-	struct wlr_output *wlr_output = renderer->sway_output->wlr_output;
-
 	float gl_matrix[9];
 	wlr_matrix_multiply(gl_matrix, renderer->projection, matrix);
 
@@ -654,66 +660,6 @@ void fx_render_border_corner(struct fx_renderer *renderer, const struct wlr_box 
 	glUniform1f(renderer->shaders.corner.is_top_right, corner_location == TOP_RIGHT);
 	glUniform1f(renderer->shaders.corner.is_bottom_left, corner_location == BOTTOM_LEFT);
 	glUniform1f(renderer->shaders.corner.is_bottom_right, corner_location == BOTTOM_RIGHT);
-
-	// TODO: Remove this ugly abomination with a complete border rework...
-	bool top_left = false;
-	bool top_right = false;
-	bool bottom_left = false;
-	bool bottom_right = false;
-	switch (wlr_output_transform_invert(wlr_output->transform)) {
-		case WL_OUTPUT_TRANSFORM_NORMAL:
-			top_left = corner_location == TOP_LEFT;
-			top_right = corner_location == TOP_RIGHT;
-			bottom_left = corner_location == BOTTOM_LEFT;
-			bottom_right = corner_location == BOTTOM_RIGHT;
-			break;
-		case WL_OUTPUT_TRANSFORM_90:
-			top_left = corner_location == BOTTOM_LEFT;
-			top_right = corner_location == TOP_LEFT;
-			bottom_left = corner_location == BOTTOM_RIGHT;
-			bottom_right = corner_location == TOP_RIGHT;
-			break;
-		case WL_OUTPUT_TRANSFORM_180:
-			top_left = corner_location == BOTTOM_RIGHT;
-			top_right = corner_location == BOTTOM_LEFT;
-			bottom_left = corner_location == TOP_RIGHT;
-			bottom_right = corner_location == TOP_LEFT;
-			break;
-		case WL_OUTPUT_TRANSFORM_270:
-			top_left = corner_location == TOP_RIGHT;
-			top_right = corner_location == BOTTOM_RIGHT;
-			bottom_left = corner_location == TOP_LEFT;
-			bottom_right = corner_location == BOTTOM_LEFT;
-			break;
-		case WL_OUTPUT_TRANSFORM_FLIPPED:
-			top_left = corner_location == TOP_RIGHT;
-			top_right = corner_location == TOP_LEFT;
-			bottom_left = corner_location == BOTTOM_RIGHT;
-			bottom_right = corner_location == BOTTOM_LEFT;
-			break;
-		case WL_OUTPUT_TRANSFORM_FLIPPED_90:
-			top_left = corner_location == TOP_LEFT;
-			top_right = corner_location == BOTTOM_LEFT;
-			bottom_left = corner_location == TOP_RIGHT;
-			bottom_right = corner_location == BOTTOM_RIGHT;
-			break;
-		case WL_OUTPUT_TRANSFORM_FLIPPED_180:
-			top_left = corner_location == BOTTOM_LEFT;
-			top_right = corner_location == BOTTOM_RIGHT;
-			bottom_left = corner_location == TOP_LEFT;
-			bottom_right = corner_location == TOP_RIGHT;
-			break;
-		case WL_OUTPUT_TRANSFORM_FLIPPED_270:
-			top_left = corner_location == BOTTOM_RIGHT;
-			top_right = corner_location == TOP_RIGHT;
-			bottom_left = corner_location == BOTTOM_LEFT;
-			bottom_right = corner_location == TOP_LEFT;
-			break;
-	}
-	glUniform1f(renderer->shaders.corner.is_top_left, top_left);
-	glUniform1f(renderer->shaders.corner.is_top_right, top_right);
-	glUniform1f(renderer->shaders.corner.is_bottom_left, bottom_left);
-	glUniform1f(renderer->shaders.corner.is_bottom_right, bottom_right);
 
 	glUniform2f(renderer->shaders.corner.position, box->x, box->y);
 	glUniform1f(renderer->shaders.corner.radius, radius);

--- a/sway/desktop/fx_renderer/fx_renderer.c
+++ b/sway/desktop/fx_renderer/fx_renderer.c
@@ -41,7 +41,7 @@ static void create_stencil_buffer(GLuint *buffer_id, int width, int height) {
 
 	glGenRenderbuffers(1, buffer_id);
 	glBindRenderbuffer(GL_RENDERBUFFER, *buffer_id);
-	glRenderbufferStorage(GL_RENDERBUFFER, GL_STENCIL_INDEX8, width, height);
+	glRenderbufferStorage(GL_RENDERBUFFER, GL_STENCIL_INDEX8, monitor_box.width, monitor_box.height);
 	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, *buffer_id);
 	GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
 	if (status != GL_FRAMEBUFFER_COMPLETE) {
@@ -394,7 +394,7 @@ void fx_renderer_begin(struct fx_renderer *renderer, int width, int height) {
 	create_stencil_buffer(&renderer->stencil_buffer_id, width, height);
 
 	// refresh projection matrix
-	matrix_projection(renderer->projection, width, height,
+	matrix_projection(renderer->projection, monitor_box.width, monitor_box.height,
 		WL_OUTPUT_TRANSFORM_FLIPPED_180);
 
 	glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);

--- a/sway/desktop/fx_renderer/shaders/quad_round.frag
+++ b/sway/desktop/fx_renderer/shaders/quad_round.frag
@@ -1,6 +1,8 @@
 #define SOURCE_QUAD_ROUND 1
 #define SOURCE_QUAD_ROUND_TOP_LEFT 2
 #define SOURCE_QUAD_ROUND_TOP_RIGHT 3
+#define SOURCE_QUAD_ROUND_BOTTOM_RIGHT 4
+#define SOURCE_QUAD_ROUND_BOTTOM_LEFT 5
 
 #if !defined(SOURCE)
 #error "Missing shader preamble"
@@ -22,6 +24,10 @@ vec2 getCornerDist() {
     return abs(gl_FragCoord.xy - position - size) - size + radius;
 #elif SOURCE == SOURCE_QUAD_ROUND_TOP_RIGHT
     return abs(gl_FragCoord.xy - position - vec2(0, size.y)) - size + radius;
+#elif SOURCE == SOURCE_QUAD_ROUND_BOTTOM_RIGHT
+    return abs(gl_FragCoord.xy - position) - size + radius;
+#elif SOURCE == SOURCE_QUAD_ROUND_BOTTOM_LEFT
+    return abs(gl_FragCoord.xy - position - vec2(size.x, 0)) - size + radius;
 #endif
 }
 

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -155,10 +155,10 @@ static void render_texture(struct wlr_output *wlr_output,
 		scissor_output(wlr_output, &rects[i]);
 		set_scale_filter(wlr_output, texture, output->scale_filter);
 		if (src_box != NULL) {
-			fx_render_subtexture_with_matrix(renderer, texture, src_box, dst_box,
+			fx_render_subtexture_with_matrix(renderer, texture, wlr_output, src_box, dst_box,
 					matrix, deco_data);
 		} else {
-			fx_render_texture_with_matrix(renderer, texture, dst_box, matrix, deco_data);
+			fx_render_texture_with_matrix(renderer, texture, wlr_output, dst_box, matrix, deco_data);
 		}
 	}
 
@@ -549,7 +549,7 @@ void render_rounded_rect(struct sway_output *output, pixman_region32_t *output_d
 	pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);
 	for (int i = 0; i < nrects; ++i) {
 		scissor_output(wlr_output, &rects[i]);
-		fx_render_rounded_rect(renderer, &box, color, wlr_output->transform_matrix,
+		fx_render_rounded_rect(renderer, wlr_output, &box, color, wlr_output->transform_matrix,
 				corner_radius, corner_location);
 	}
 
@@ -580,7 +580,7 @@ void render_border_corner(struct sway_output *output, pixman_region32_t *output_
 	pixman_box32_t *rects = pixman_region32_rectangles(&damage, &nrects);
 	for (int i = 0; i < nrects; ++i) {
 		scissor_output(wlr_output, &rects[i]);
-		fx_render_border_corner(renderer, &box, color, wlr_output->transform_matrix,
+		fx_render_border_corner(renderer, wlr_output, &box, color, wlr_output->transform_matrix,
 				corner_location, corner_radius, border_thickness);
 	}
 
@@ -625,7 +625,7 @@ void render_box_shadow(struct sway_output *output, pixman_region32_t *output_dam
 	for (int i = 0; i < nrects; ++i) {
 		scissor_output(wlr_output, &rects[i]);
 
-		fx_render_box_shadow(renderer, &box, color,
+		fx_render_box_shadow(renderer, wlr_output, &box, color,
 				wlr_output->transform_matrix, corner_radius, blur_sigma);
 	}
 

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -65,6 +65,7 @@ bool should_parameters_blur() {
 	return config->blur_params.radius > 0 && config->blur_params.num_passes > 0;
 }
 
+// TODO: contribute wlroots function to allow creating an fbox from a box?
 struct wlr_fbox wlr_fbox_from_wlr_box(struct wlr_box *box) {
 	return (struct wlr_fbox) {
 		.x = box->x,
@@ -238,7 +239,7 @@ void render_blur_segments(struct fx_renderer *renderer,
 	}
 }
 
-/** Blurs the main_buffer content and returns the blurred framebuffer */
+// Blurs the main_buffer content and returns the blurred framebuffer
 struct fx_framebuffer *get_main_buffer_blur(struct fx_renderer *renderer, struct sway_output *output,
 		pixman_region32_t *original_damage, const float box_matrix[static 9], const struct wlr_box *box) {
 	struct wlr_output *wlr_output = output->wlr_output;
@@ -384,6 +385,7 @@ static void render_surface_iterator(struct sway_output *output,
 	}
 
 	struct wlr_box proj_box = *_box;
+
 	scale_box(&proj_box, wlr_output->scale);
 
 	float matrix[9];
@@ -825,7 +827,6 @@ static void render_saved_view(struct sway_view *view, struct sway_output *output
 				struct wlr_box monitor_box = get_monitor_box(wlr_output);
 				wlr_box_transform(&monitor_box, &monitor_box,
 						wlr_output_transform_invert(wlr_output->transform), monitor_box.width, monitor_box.height);
-				// TODO: contribute wlroots function to allow creating an fbox from a box?
 				struct wlr_fbox src_box = wlr_fbox_from_wlr_box(&monitor_box);
 				bool is_floating = container_is_floating(view->container);
 				render_blur(!is_floating, output, damage, &src_box, &dst_box, &opaque_region,

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1842,11 +1842,16 @@ void output_render(struct sway_output *output, struct timespec *when,
 		fullscreen_con = workspace->current.fullscreen;
 	}
 
+
+	struct wlr_box monitor_box = get_monitor_box(wlr_output);
+	wlr_box_transform(&monitor_box, &monitor_box,
+			wlr_output_transform_invert(wlr_output->transform),
+			monitor_box.width, monitor_box.height);
+
+	fx_renderer_begin(renderer, monitor_box.width, monitor_box.height);
+
 	int width, height;
 	wlr_output_transformed_resolution(wlr_output, &width, &height);
-
-	fx_renderer_begin(renderer, width, height);
-
 	if (debug.damage == DAMAGE_RERENDER) {
 		pixman_region32_union_rect(damage, damage, 0, 0, width, height);
 	}

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -255,7 +255,7 @@ struct fx_framebuffer *get_main_buffer_blur(struct fx_renderer *renderer, struct
 	pixman_region32_t damage;
 	pixman_region32_init(&damage);
 	pixman_region32_copy(&damage, original_damage);
-	wlr_region_transform(&damage, &damage, wlr_output_transform_invert(wlr_output->transform),
+	wlr_region_transform(&damage, &damage, transform,
 			monitor_box.width, monitor_box.height);
 	wlr_region_expand(&damage, &damage, get_blur_size());
 
@@ -527,7 +527,8 @@ void render_monitor_blur(struct sway_output *output, pixman_region32_t *damage) 
 			wlr_output->transform_matrix, &monitor_box);
 
 	// Render the newly blurred content into the blur_buffer
-	fx_framebuffer_create(&renderer->blur_buffer, monitor_box.width, monitor_box.height, true);
+	fx_framebuffer_create(&renderer->blur_buffer,
+			output->renderer->viewport_width, output->renderer->viewport_height, true);
 	// Clear the damaged region of the blur_buffer
 	float clear_color[] = { 0, 0, 0, 0 };
 	int nrects;

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -178,7 +178,6 @@ void render_blur_segments(struct fx_renderer *renderer,
 		const float matrix[static 9], pixman_region32_t* damage,
 		struct fx_framebuffer **buffer, struct blur_shader* shader,
 		const struct wlr_box *box, int blur_radius) {
-
 	if (*buffer == &renderer->effects_buffer) {
 		fx_framebuffer_bind(&renderer->effects_buffer_swapped);
 	} else {
@@ -206,11 +205,12 @@ void render_blur_segments(struct fx_renderer *renderer,
 /** Blurs the main_buffer content and returns the blurred framebuffer */
 struct fx_framebuffer *get_main_buffer_blur(struct fx_renderer *renderer, struct sway_output *output,
 		pixman_region32_t *original_damage, const float box_matrix[static 9], const struct wlr_box *box) {
-	struct wlr_box monitor_box = get_monitor_box(output->wlr_output);
+	struct wlr_output *wlr_output = output->wlr_output;
+	struct wlr_box monitor_box = get_monitor_box(wlr_output);
 
-	const enum wl_output_transform transform = wlr_output_transform_invert(output->wlr_output->transform);
+	const enum wl_output_transform transform = wlr_output_transform_invert(wlr_output->transform);
 	float matrix[9];
-	wlr_matrix_project_box(matrix, &monitor_box, transform, 0, output->wlr_output->transform_matrix);
+	wlr_matrix_project_box(matrix, &monitor_box, transform, 0, wlr_output->transform_matrix);
 
 	float gl_matrix[9];
 	wlr_matrix_multiply(gl_matrix, renderer->projection, matrix);
@@ -218,7 +218,7 @@ struct fx_framebuffer *get_main_buffer_blur(struct fx_renderer *renderer, struct
 	pixman_region32_t damage;
 	pixman_region32_init(&damage);
 	pixman_region32_copy(&damage, original_damage);
-	wlr_region_transform(&damage, &damage, wlr_output_transform_invert(output->wlr_output->transform),
+	wlr_region_transform(&damage, &damage, wlr_output_transform_invert(wlr_output->transform),
 			monitor_box.width, monitor_box.height);
 	wlr_region_expand(&damage, &damage, get_blur_size());
 
@@ -1986,7 +1986,11 @@ render_overlay:
 
 renderer_end:
 	// Draw the contents of our buffer into the wlr buffer
+<<<<<<< HEAD
 	fx_framebuffer_bind(&renderer->wlr_buffer);
+=======
+	fx_framebuffer_bind(&renderer->wlr_buffer, wlr_output);
+>>>>>>> f1ff836b (Fixed rendering)
 	float clear_color[] = {0.0f, 0.0f, 0.0f, 1.0f};
 	if (pixman_region32_not_empty(&extended_damage)) {
 		int nrects;


### PR DESCRIPTION
Fixes: #47

Some things don't work (mostly position dependent rounding).

Todo:

- [ ] ~Per-side window rounding with titlebars~
- [x] Window border corners
- [x] Rounded quad frag shader

Issues:

![image](https://user-images.githubusercontent.com/35975961/218811077-443e071b-1272-4346-8087-185bb0410595.png)

![image](https://user-images.githubusercontent.com/35975961/218811189-46dee0bc-e8f8-4e60-8a8a-2c29b29a38ae.png)

Everything else should work 🤞

Testing:

1. I recommend to create a local simple sway config with a different MOD key (I use alt) for testing. 
2. Add this to said config:
```
output WL-1 {
	transform 270
}
```
3. Run in a terminal in nested mode with said config

