### PR TITLE
Extend minimize logic to work with XWayland and XDG applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Sway is an incredible window manager, and certainly one of the most well establi
     - `dim_inactive_colors.urgent <hex color> ex, #900000FF`
 + Application saturation: `for_window [CRITERIA HERE] saturation <set|plus|minus> <val 0.0 <-> 2.0>`
 + Keep/remove separator border between titlebar and content: `titlebar_separator enable|disable`
++ Treat Scratchpad as minimized: `scratchpad_minimize on|off`
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Sway is an incredible window manager, and certainly one of the most well establi
     - `dim_inactive_colors.urgent <hex color> ex, #900000FF`
 + Application saturation: `for_window [CRITERIA HERE] saturation <set|plus|minus> <val 0.0 <-> 2.0>`
 + Keep/remove separator border between titlebar and content: `titlebar_separator enable|disable`
-+ Treat Scratchpad as minimized: `scratchpad_minimize on|off`
++ Treat Scratchpad as minimized: `scratchpad_minimize enable|disable`
 
 ## Roadmap
 

--- a/config.in
+++ b/config.in
@@ -34,8 +34,8 @@ dim_inactive 0.0
 dim_inactive_colors.unfocused #000000FF
 dim_inactive_colors.urgent #900000FF
 
-# Move minimized windows into Scratchpad
-scratchpad_minimize on
+# Move minimized windows into Scratchpad (enable|disable)
+scratchpad_minimize enable
 
 ### Output configuration
 #

--- a/config.in
+++ b/config.in
@@ -34,6 +34,9 @@ dim_inactive 0.0
 dim_inactive_colors.unfocused #000000FF
 dim_inactive_colors.urgent #900000FF
 
+# Move minimized windows into Scratchpad
+scratchpad_minimize off
+
 ### Output configuration
 #
 # Default wallpaper (more resolutions are available in @datadir@/backgrounds/sway/)

--- a/config.in
+++ b/config.in
@@ -35,7 +35,7 @@ dim_inactive_colors.unfocused #000000FF
 dim_inactive_colors.urgent #900000FF
 
 # Move minimized windows into Scratchpad
-scratchpad_minimize off
+scratchpad_minimize on
 
 ### Output configuration
 #

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -176,6 +176,7 @@ sway_cmd cmd_reload;
 sway_cmd cmd_rename;
 sway_cmd cmd_resize;
 sway_cmd cmd_scratchpad;
+sway_cmd cmd_scratchpad_minimize;
 sway_cmd cmd_seamless_mouse;
 sway_cmd cmd_set;
 sway_cmd cmd_shortcuts_inhibitor;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -488,6 +488,7 @@ struct sway_config {
 	int shadow_blur_sigma;
 	float shadow_color[4];
 	bool titlebar_separator;
+	bool scratchpad_minimize;
 
 	char *swaynag_command;
 	struct swaynag_instance swaynag_config_errors;

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -134,6 +134,7 @@ struct sway_xdg_shell_view {
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
 	struct wl_listener request_maximize;
+	struct wl_listener request_minimize;
 	struct wl_listener request_fullscreen;
 	struct wl_listener set_title;
 	struct wl_listener set_app_id;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -115,6 +115,7 @@ static const struct cmd_handler handlers[] = {
 static const struct cmd_handler config_handlers[] = {
 	{ "default_orientation", cmd_default_orientation },
 	{ "include", cmd_include },
+	{ "scratchpad_minimize", cmd_scratchpad_minimize },
 	{ "swaybg_command", cmd_swaybg_command },
 	{ "swaynag_command", cmd_swaynag_command },
 	{ "workspace_layout", cmd_workspace_layout },

--- a/sway/commands/scratchpad_minimize.c
+++ b/sway/commands/scratchpad_minimize.c
@@ -1,0 +1,18 @@
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "log.h"
+#include "stringop.h"
+#include "util.h"
+
+struct cmd_results *cmd_scratchpad_minimize(int argc, char **argv) {
+	struct cmd_results *error = checkarg(argc, "scratchpad_minimize", EXPECTED_AT_LEAST, 1);
+
+	if (error) {
+		return error;
+	}
+
+	config->scratchpad_minimize = parse_boolean(argv[0], config->scratchpad_minimize);
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -344,7 +344,7 @@ static void config_defaults(struct sway_config *config) {
 	config->shadow_blur_sigma = 20.0f;
 	color_to_rgba(config->shadow_color, 0x0000007F);
 	config->titlebar_separator = true;
-	config->scratchpad_minimize = false;
+	config->scratchpad_minimize = true;
 
 	// The keysym to keycode translation
 	struct xkb_rule_names rules = {0};

--- a/sway/config.c
+++ b/sway/config.c
@@ -344,6 +344,7 @@ static void config_defaults(struct sway_config *config) {
 	config->shadow_blur_sigma = 20.0f;
 	color_to_rgba(config->shadow_color, 0x0000007F);
 	config->titlebar_separator = true;
+	config->scratchpad_minimize = false;
 
 	// The keysym to keycode translation
 	struct xkb_rule_names rules = {0};

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -336,6 +336,11 @@ static void handle_request_maximize(struct wl_listener *listener, void *data) {
 static void handle_request_minimize(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		wl_container_of(listener, xdg_shell_view, request_minimize);
+	if (!config->scratchpad_minimize) {
+		struct wlr_xdg_toplevel *toplevel = xdg_shell_view->view.wlr_xdg_toplevel;
+		wlr_xdg_surface_schedule_configure(toplevel->base);
+		return;
+	}
 
 	struct sway_container *container = xdg_shell_view->view.container;
 	if (!container->pending.workspace) {

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -332,6 +332,25 @@ static void handle_request_maximize(struct wl_listener *listener, void *data) {
 	wlr_xdg_surface_schedule_configure(toplevel->base);
 }
 
+/* Minimize to scratchpad */
+static void handle_request_minimize(struct wl_listener *listener, void *data) {
+	struct sway_xdg_shell_view *xdg_shell_view =
+		wl_container_of(listener, xdg_shell_view, request_minimize);
+
+	struct sway_container *container = xdg_shell_view->view.container;
+	if (!container->pending.workspace) {
+		while (container->pending.parent) {
+			container = container->pending.parent;
+		}
+	}
+	if (!container->scratchpad) {
+		root_scratchpad_add_container(container, NULL);
+	} else if (container->pending.workspace) {
+		root_scratchpad_hide(container);
+	}
+	transaction_commit_dirty();
+}
+
 static void handle_request_fullscreen(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		wl_container_of(listener, xdg_shell_view, request_fullscreen);
@@ -406,6 +425,7 @@ static void handle_unmap(struct wl_listener *listener, void *data) {
 	wl_list_remove(&xdg_shell_view->commit.link);
 	wl_list_remove(&xdg_shell_view->new_popup.link);
 	wl_list_remove(&xdg_shell_view->request_maximize.link);
+	wl_list_remove(&xdg_shell_view->request_minimize.link);
 	wl_list_remove(&xdg_shell_view->request_fullscreen.link);
 	wl_list_remove(&xdg_shell_view->request_move.link);
 	wl_list_remove(&xdg_shell_view->request_resize.link);
@@ -457,6 +477,10 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	xdg_shell_view->request_maximize.notify = handle_request_maximize;
 	wl_signal_add(&toplevel->events.request_maximize,
 			&xdg_shell_view->request_maximize);
+
+	xdg_shell_view->request_minimize.notify = handle_request_minimize;
+	wl_signal_add(&toplevel->events.request_minimize,
+			&xdg_shell_view->request_minimize);
 
 	xdg_shell_view->request_fullscreen.notify = handle_request_fullscreen;
 	wl_signal_add(&toplevel->events.request_fullscreen,

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -586,24 +586,30 @@ static void handle_request_minimize(struct wl_listener *listener, void *data) {
 	}
 
 	struct wlr_xwayland_minimize_event *e = data;
-	struct sway_container *container = view->container;
-	if (!container->pending.workspace) {
-		while (container->pending.parent) {
-			container = container->pending.parent;
+	if (config->scratchpad_minimize) {
+		struct sway_container *container = view->container;
+		if (!container->pending.workspace) {
+			while (container->pending.parent) {
+				container = container->pending.parent;
+			}
 		}
+		if(e->minimize) {
+			if (!container->scratchpad) {
+				root_scratchpad_add_container(container, NULL);
+			} else if (container->pending.workspace) {
+				root_scratchpad_hide(container);
+			}
+		} else {
+			if(container->scratchpad) {
+				root_scratchpad_show(container);
+			}
+		}
+		transaction_commit_dirty();
+		return;
 	}
-	if(e->minimize) {
-		if (!container->scratchpad) {
-			root_scratchpad_add_container(container, NULL);
-		} else if (container->pending.workspace) {
-			root_scratchpad_hide(container);
-		}
-	} else {
-		if(container->scratchpad) {
-			root_scratchpad_show(container);
-		}
-	}
-	transaction_commit_dirty();
+	struct sway_seat *seat = input_manager_current_seat();
+	bool focused = seat_get_focus(seat) == &view->container->node;
+	wlr_xwayland_surface_set_minimized(xsurface, !focused && e->minimize);
 }
 
 static void handle_request_move(struct wl_listener *listener, void *data) {

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -598,11 +598,9 @@ static void handle_request_minimize(struct wl_listener *listener, void *data) {
 		} else if (container->pending.workspace) {
 			root_scratchpad_hide(container);
 		}
-		wlr_xwayland_surface_set_minimized(xsurface, true);
 	} else {
 		if(container->scratchpad) {
 			root_scratchpad_show(container);
-			wlr_xwayland_surface_set_minimized(xsurface, false);
 		}
 	}
 	transaction_commit_dirty();

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -98,6 +98,7 @@ sway_sources = files(
 	'commands/resize.c',
 	'commands/saturation.c',
 	'commands/scratchpad.c',
+	'commands/scratchpad_minimize.c',
 	'commands/seat.c',
 	'commands/seat/attach.c',
 	'commands/seat/cursor.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -71,6 +71,10 @@ The following commands may only be used in the configuration file.
 	*wordexp*(3) for details). The same include file can only be included once;
 	subsequent attempts will be ignored.
 
+*scratchpad_minimize* <value>
+	Adjusts if minimized windows should be moved into the scratchpad (on|off).
+	Must be set at config-time (when starting sway).
+
 *swaybg_command* <command>
 	Executes custom background _command_. Default is _swaybg_. Refer to
 	*sway-output*(5) for more information.

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -72,8 +72,8 @@ The following commands may only be used in the configuration file.
 	subsequent attempts will be ignored.
 
 *scratchpad_minimize* <value>
-	Adjusts if minimized windows should be moved into the scratchpad (on|off).
-	Must be set at config-time (when starting sway).
+	Adjusts if minimized windows should be moved into the scratchpad
+	(enable|disable). Must be set at config-time (when starting sway).
 
 *swaybg_command* <command>
 	Executes custom background _command_. Default is _swaybg_. Refer to

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -58,8 +58,8 @@ void root_destroy(struct sway_root *root) {
 /* Set minimized state from scratchpad container `show` state */
 static void root_scratchpad_set_minimize(struct sway_container *con, bool minimize) {
 	struct wlr_foreign_toplevel_handle_v1 *foreign_toplevel = con->view->foreign_toplevel;
-	struct wlr_xwayland_surface *xsurface = con->view->wlr_xwayland_surface;
-	if (xsurface) {
+	if (wlr_surface_is_xwayland_surface(con->view->surface)) {
+		struct wlr_xwayland_surface *xsurface = wlr_xwayland_surface_from_wlr_surface(con->view->surface);
 		wlr_xwayland_surface_set_minimized(xsurface, minimize);
 	} else if (foreign_toplevel) {
 		wlr_foreign_toplevel_handle_v1_set_minimized(foreign_toplevel, minimize);

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -108,7 +108,9 @@ void root_scratchpad_add_container(struct sway_container *con, struct sway_works
 	}
 
 	// Set minimize state to minimized
-	root_scratchpad_set_minimize(con, true);
+	if (config->scratchpad_minimize) {
+		root_scratchpad_set_minimize(con, true);
+	}
 
 	ipc_event_window(con, "move");
 }
@@ -156,7 +158,9 @@ void root_scratchpad_show(struct sway_container *con) {
 	workspace_add_floating(new_ws, con);
 
 	// Set minimize state to normalized
-	root_scratchpad_set_minimize(con, false);
+	if (config->scratchpad_minimize) {
+		root_scratchpad_set_minimize(con, false);
+	}
 
 	// Make sure the container's center point overlaps this workspace
 	double center_lx = con->pending.x + con->pending.width / 2;
@@ -190,7 +194,9 @@ void root_scratchpad_hide(struct sway_container *con) {
 	}
 
 	// Set minimize state to minimized
-	root_scratchpad_set_minimize(con, true);
+	if (config->scratchpad_minimize) {
+		root_scratchpad_set_minimize(con, true);
+	}
 
 	disable_fullscreen(con, NULL);
 	container_for_each_child(con, disable_fullscreen, NULL);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -712,6 +712,8 @@ static void handle_foreign_fullscreen_request(
 
 static void handle_foreign_minimize(
 		struct wl_listener *listener, void *data) {
+	if (!config->scratchpad_minimize) return;
+
 	struct sway_view *view = wl_container_of(
 			listener, view, foreign_minimize);
 	struct wlr_foreign_toplevel_handle_v1_minimized_event *event = data;


### PR DESCRIPTION
Fixes minimize button not working on applications like GTK apps and Riot launcher not minimizing.

This also improves the initial logic and sets the toplevel minimize state when thrown into scratchpad. I'm not sure if this is desired or not but it seems logical to me to treat the scratchpad as minimize :)

This fixes being able to screenshare scratchpad XWayland windows through Discord or any other software