### PR TITLE
Blur damage tracking simplification

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -761,6 +761,8 @@ void translate_keysyms(struct input_config *input_config);
 
 void binding_add_translated(struct sway_binding *binding, list_t *bindings);
 
+int get_config_blur_size();
+
 /* Global config singleton. */
 extern struct sway_config *config;
 

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -761,8 +761,6 @@ void translate_keysyms(struct input_config *input_config);
 
 void binding_add_translated(struct sway_binding *binding, list_t *bindings);
 
-int get_config_blur_size();
-
 /* Global config singleton. */
 extern struct sway_config *config;
 

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -761,6 +761,10 @@ void translate_keysyms(struct input_config *input_config);
 
 void binding_add_translated(struct sway_binding *binding, list_t *bindings);
 
+int config_get_blur_size();
+
+bool config_should_parameters_blur();
+
 /* Global config singleton. */
 extern struct sway_config *config;
 

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -92,6 +92,8 @@ struct sway_output *workspace_output_get_highest_available(
 
 void workspace_detect_urgent(struct sway_workspace *workspace);
 
+bool should_workspace_need_optimized_blur(struct sway_workspace *ws);
+
 void workspace_for_each_container(struct sway_workspace *ws,
 		void (*f)(struct sway_container *con, void *data), void *data);
 

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -92,7 +92,7 @@ struct sway_output *workspace_output_get_highest_available(
 
 void workspace_detect_urgent(struct sway_workspace *workspace);
 
-bool should_workspace_need_optimized_blur(struct sway_workspace *ws);
+bool should_workspace_have_blur(struct sway_workspace *ws);
 
 void workspace_for_each_container(struct sway_workspace *ws,
 		void (*f)(struct sway_container *con, void *data), void *data);

--- a/sway/config.c
+++ b/sway/config.c
@@ -1084,3 +1084,11 @@ void translate_keysyms(struct input_config *input_config) {
 	sway_log(SWAY_DEBUG, "Translated keysyms using config for device '%s'",
 			input_config->identifier);
 }
+
+int config_get_blur_size() {
+	return pow(2, config->blur_params.num_passes) * config->blur_params.radius;
+}
+
+bool config_should_parameters_blur() {
+	return config->blur_params.radius > 0 && config->blur_params.num_passes > 0;
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -1084,7 +1084,3 @@ void translate_keysyms(struct input_config *input_config) {
 	sway_log(SWAY_DEBUG, "Translated keysyms using config for device '%s'",
 			input_config->identifier);
 }
-
-int get_config_blur_size() {
-	return pow(2, config->blur_params.num_passes) * config->blur_params.radius;
-}

--- a/sway/config.c
+++ b/sway/config.c
@@ -1084,3 +1084,7 @@ void translate_keysyms(struct input_config *input_config) {
 	sway_log(SWAY_DEBUG, "Translated keysyms using config for device '%s'",
 			input_config->identifier);
 }
+
+int get_config_blur_size() {
+	return pow(2, config->blur_params.num_passes) * config->blur_params.radius;
+}

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -746,13 +746,15 @@ static void damage_child_views_iterator(struct sway_container *con,
 void output_damage_whole_container(struct sway_output *output,
 		struct sway_container *con) {
 	int shadow_sigma = con->shadow_enabled ? config->shadow_blur_sigma : 0;
+	int blur_size = con->blur_enabled ? config_get_blur_size() : 0;
+	int effect_size = MAX(shadow_sigma, blur_size);
 
 	// Pad the box by 1px, because the width is a double and might be a fraction
 	struct wlr_box box = {
-		.x = con->current.x - output->lx - 1 - shadow_sigma,
-		.y = con->current.y - output->ly - 1 - shadow_sigma,
-		.width = con->current.width + 2 + shadow_sigma * 2,
-		.height = con->current.height + 2 + shadow_sigma * 2,
+		.x = con->current.x - output->lx - 1 - effect_size,
+		.y = con->current.y - output->ly - 1 - effect_size,
+		.width = con->current.width + 2 + effect_size * 2,
+		.height = con->current.height + 2 + effect_size * 2,
 	};
 	scale_box(&box, output->wlr_output->scale);
 	if (wlr_damage_ring_add_box(&output->damage_ring, &box)) {

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -746,17 +746,13 @@ static void damage_child_views_iterator(struct sway_container *con,
 void output_damage_whole_container(struct sway_output *output,
 		struct sway_container *con) {
 	int shadow_sigma = con->shadow_enabled ? config->shadow_blur_sigma : 0;
-	int blur_size = con->blur_enabled ?
-			pow(2, config->blur_params.num_passes) * config->blur_params.radius : 0;
-	// +1 as a margin of error
-	int effect_size = MAX(shadow_sigma, blur_size) + 1;
 
 	// Pad the box by 1px, because the width is a double and might be a fraction
 	struct wlr_box box = {
-		.x = con->current.x - output->lx - 1 - effect_size,
-		.y = con->current.y - output->ly - 1 - effect_size,
-		.width = con->current.width + 2 + effect_size * 2,
-		.height = con->current.height + 2 + effect_size * 2,
+		.x = con->current.x - output->lx - 1 - shadow_sigma,
+		.y = con->current.y - output->ly - 1 - shadow_sigma,
+		.width = con->current.width + 2 + shadow_sigma * 2,
+		.height = con->current.height + 2 + shadow_sigma * 2,
 	};
 	scale_box(&box, output->wlr_output->scale);
 	if (wlr_damage_ring_add_box(&output->damage_ring, &box)) {

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -746,7 +746,8 @@ static void damage_child_views_iterator(struct sway_container *con,
 void output_damage_whole_container(struct sway_output *output,
 		struct sway_container *con) {
 	int shadow_sigma = con->shadow_enabled ? config->shadow_blur_sigma : 0;
-	int blur_size = con->blur_enabled ? get_config_blur_size() : 0;
+	int blur_size = con->blur_enabled ?
+			pow(2, config->blur_params.num_passes) * config->blur_params.radius : 0;
 	// +1 as a margin of error
 	int effect_size = MAX(shadow_sigma, blur_size) + 1;
 

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -230,7 +230,7 @@ void render_blur_segments(struct fx_renderer *renderer,
 
 // Blurs the main_buffer content and returns the blurred framebuffer
 struct fx_framebuffer *get_main_buffer_blur(struct fx_renderer *renderer, struct sway_output *output,
-		pixman_region32_t *original_damage, const float box_matrix[static 9], const struct wlr_box *box) {
+		pixman_region32_t *original_damage, const struct wlr_box *box) {
 	struct wlr_output *wlr_output = output->wlr_output;
 	struct wlr_box monitor_box = get_monitor_box(wlr_output);
 
@@ -244,8 +244,7 @@ struct fx_framebuffer *get_main_buffer_blur(struct fx_renderer *renderer, struct
 	pixman_region32_t damage;
 	pixman_region32_init(&damage);
 	pixman_region32_copy(&damage, original_damage);
-	wlr_region_transform(&damage, &damage, transform,
-			monitor_box.width, monitor_box.height);
+	wlr_region_transform(&damage, &damage, transform, monitor_box.width, monitor_box.height);
 
 	int blur_size = pow(2, config->blur_params.num_passes) * config->blur_params.radius;
 	wlr_region_expand(&damage, &damage, blur_size);
@@ -343,8 +342,7 @@ void render_blur(bool optimized, struct sway_output *output,
 		pixman_region32_intersect(&inverse_opaque, &inverse_opaque, &damage);
 
 		// Render the blur into its own buffer
-		buffer = get_main_buffer_blur(renderer, output, &inverse_opaque,
-				wlr_output->transform_matrix, dst_box);
+		buffer = get_main_buffer_blur(renderer, output, &inverse_opaque, dst_box);
 	}
 
 	// Draw the blurred texture
@@ -516,8 +514,7 @@ void render_monitor_blur(struct sway_output *output, pixman_region32_t *damage) 
 	pixman_region32_init_rect(&fake_damage, 0, 0, monitor_box.width, monitor_box.height);
 
 	// Render the blur
-	struct fx_framebuffer *buffer = get_main_buffer_blur(renderer, output, &fake_damage,
-			wlr_output->transform_matrix, &monitor_box);
+	struct fx_framebuffer *buffer = get_main_buffer_blur(renderer, output, &fake_damage, &monitor_box);
 
 	// Render the newly blurred content into the blur_buffer
 	fx_framebuffer_create(&renderer->blur_buffer,

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1,4 +1,3 @@
-#include <stdint.h>
 #include <stdio.h>
 #include <assert.h>
 #include <GLES2/gl2.h>
@@ -483,7 +482,7 @@ void render_whole_output(struct fx_renderer *renderer, struct wlr_output *wlr_ou
 	render_texture(wlr_output, output_damage, texture, NULL, &monitor_box, matrix, get_undecorated_decoration_data());
 }
 
-void render_monitor_blur(struct sway_output *output, pixman_region32_t *damage) {
+void render_output_blur(struct sway_output *output, pixman_region32_t *damage) {
 	struct wlr_output *wlr_output = output->wlr_output;
 	struct fx_renderer *renderer = output->renderer;
 
@@ -1885,7 +1884,7 @@ void output_render(struct sway_output *output, struct timespec *when,
 		// check if the background needs to be blurred
 		if (config_should_parameters_blur() && renderer->blur_buffer_dirty && should_render_blur) {
 			pixman_region32_union_rect(damage, damage, 0, 0, output_width, output_height);
-			render_monitor_blur(output, damage);
+			render_output_blur(output, damage);
 		}
 
 		render_workspace(output, damage, workspace, workspace->current.focused);

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -50,12 +50,12 @@ struct decoration_data get_undecorated_decoration_data() {
 	};
 }
 
-bool should_parameters_blur() {
-	return config->blur_params.radius > 0 && config->blur_params.num_passes > 0;
-}
-
 int get_blur_size() {
 	return pow(2, config->blur_params.num_passes) * config->blur_params.radius;
+}
+
+bool should_parameters_blur() {
+	return config->blur_params.radius > 0 && config->blur_params.num_passes > 0;
 }
 
 // TODO: contribute wlroots function to allow creating an fbox from a box?

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1776,21 +1776,18 @@ struct find_effect_iter_data {
 
 static bool find_con_effect_iterator(struct sway_container *con, void* _data) {
 	struct sway_view *view = con->view;
-	struct find_effect_iter_data *data = _data;
-	struct workspace_effect_info *effect_info = data->effect_info;
-
 	if (!view) {
 		return false;
 	}
 
+	struct find_effect_iter_data *data = _data;
+	struct workspace_effect_info *effect_info = data->effect_info;
 	if (con->blur_enabled && !view->surface->opaque) {
 		effect_info->container_wants_blur = true;
 
 		bool is_floating = container_is_floating(con);
 		// Check if we should render optimized blur
-		if (data->blur_buffer_dirty
-				// Only test floating windows when xray is enabled
-				&& (!is_floating || (is_floating && config->blur_xray))) {
+		if (data->blur_buffer_dirty && (!is_floating || config->blur_xray)) {
 			effect_info->should_render_optimized_blur = true;
 		}
 	}

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -247,6 +247,9 @@ struct fx_framebuffer *get_main_buffer_blur(struct fx_renderer *renderer, struct
 	wlr_region_transform(&damage, &damage, transform,
 			monitor_box.width, monitor_box.height);
 
+	int blur_size = pow(2, config->blur_params.num_passes) * config->blur_params.radius;
+	wlr_region_expand(&damage, &damage, blur_size);
+
 	// Initially blur main_buffer content into the effects_buffers
 	struct fx_framebuffer *current_buffer = &renderer->main_buffer;
 

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -246,7 +246,6 @@ struct fx_framebuffer *get_main_buffer_blur(struct fx_renderer *renderer, struct
 	pixman_region32_copy(&damage, original_damage);
 	wlr_region_transform(&damage, &damage, transform,
 			monitor_box.width, monitor_box.height);
-	wlr_region_expand(&damage, &damage, get_config_blur_size());
 
 	// Initially blur main_buffer content into the effects_buffers
 	struct fx_framebuffer *current_buffer = &renderer->main_buffer;

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1850,7 +1850,6 @@ void output_render(struct sway_output *output, struct timespec *when,
 		fullscreen_con = workspace->current.fullscreen;
 	}
 
-
 	struct wlr_box monitor_box = get_monitor_box(wlr_output);
 	wlr_box_transform(&monitor_box, &monitor_box,
 			wlr_output_transform_invert(wlr_output->transform),
@@ -1864,7 +1863,6 @@ void output_render(struct sway_output *output, struct timespec *when,
 		pixman_region32_union_rect(damage, damage, 0, 0, width, height);
 	}
 
-	bool has_blur = false;
 	bool blur_optimize_should_render = false;
 	bool damage_not_empty = pixman_region32_not_empty(damage);
 	pixman_region32_t extended_damage;
@@ -1872,7 +1870,6 @@ void output_render(struct sway_output *output, struct timespec *when,
 	if (!fullscreen_con && !server.session_lock.locked && damage_not_empty) {
 		// Check if there are any windows to blur
 		struct workspace_effect_info effect_info = get_workspace_effect_info(output);
-		has_blur = effect_info.container_wants_blur || config->blur_enabled;
 		if (effect_info.should_render_optimized_blur) {
 			blur_optimize_should_render = true;
 			// Damage the whole output
@@ -1995,8 +1992,7 @@ void output_render(struct sway_output *output, struct timespec *when,
 		render_layer_toplevel(output, damage,
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]);
 
-		bool blur_enabled = has_blur && should_parameters_blur();
-		if (blur_enabled && blur_optimize_should_render && renderer->blur_buffer_dirty) {
+		if (should_parameters_blur() && blur_optimize_should_render && renderer->blur_buffer_dirty) {
 			render_monitor_blur(output, damage);
 		}
 

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1975,23 +1975,19 @@ renderer_end:
 		}
 	}
 	render_whole_output(renderer, wlr_output, damage, &renderer->main_buffer.texture);
-	fx_renderer_scissor(NULL);
 	fx_renderer_end(renderer);
 
 	// Draw the software cursors
 	wlr_renderer_begin(output->server->wlr_renderer, wlr_output->width, wlr_output->height);
 	wlr_output_render_software_cursors(wlr_output, damage);
 	wlr_renderer_end(output->server->wlr_renderer);
+
 	fx_renderer_scissor(NULL);
 
 	pixman_region32_t frame_damage;
 	pixman_region32_init(&frame_damage);
 
-	/*
-	 * Extend the frame damage by the blur size to properly calc damage for the
-	 * next buffer swap. Thanks Emersion for your excellent damage tracking blog-post!
-	 */
-
+	// Extend the frame damage by the blur size to properly calc damage for the next buffer swap
 	enum wl_output_transform transform = wlr_output_transform_invert(wlr_output->transform);
 	wlr_region_transform(&frame_damage, damage, transform, width, height);
 

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1789,15 +1789,15 @@ void output_render(struct sway_output *output, struct timespec *when,
 		pixman_region32_union_rect(damage, damage, 0, 0, width, height);
 	}
 
-	bool damage_not_empty = pixman_region32_not_empty(damage);
-
-	if (!damage_not_empty) {
+	if (!pixman_region32_not_empty(damage)) {
 		// Output isn't damaged but needs buffer swap
 		goto renderer_end;
 	}
 
 	if (debug.damage == DAMAGE_HIGHLIGHT) {
+		fx_framebuffer_bind(&renderer->wlr_buffer);
 		fx_renderer_clear((float[]){1, 1, 0, 1});
+		fx_framebuffer_bind(&renderer->main_buffer);
 	}
 
 	if (server.session_lock.locked) {

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -690,7 +690,7 @@ void workspace_detect_urgent(struct sway_workspace *workspace) {
 	}
 }
 
-static bool find_con_needing_optimized_blur(struct sway_container *con, void *data) {
+static bool find_optimized_blur_iterator(struct sway_container *con, void *data) {
 	struct sway_view *view = con->view;
 	if (!view) {
 		return false;
@@ -705,7 +705,7 @@ bool should_workspace_need_optimized_blur(struct sway_workspace *ws) {
 	if (!workspace_is_visible(ws)) {
 		return false;
 	}
-	return (bool)workspace_find_container(ws, find_con_needing_optimized_blur, NULL);
+	return (bool)workspace_find_container(ws, find_optimized_blur_iterator, NULL);
 }
 
 void workspace_for_each_container(struct sway_workspace *ws,

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -690,6 +690,24 @@ void workspace_detect_urgent(struct sway_workspace *workspace) {
 	}
 }
 
+static bool find_con_needing_optimized_blur(struct sway_container *con, void *data) {
+	struct sway_view *view = con->view;
+	if (!view) {
+		return false;
+	}
+	if (con->blur_enabled && !view->surface->opaque && (!container_is_floating(con) || config->blur_xray)) {
+		return true;
+	}
+	return false;
+}
+
+bool should_workspace_need_optimized_blur(struct sway_workspace *ws) {
+	if (!workspace_is_visible(ws)) {
+		return false;
+	}
+	return (bool)workspace_find_container(ws, find_con_needing_optimized_blur, NULL);
+}
+
 void workspace_for_each_container(struct sway_workspace *ws,
 		void (*f)(struct sway_container *con, void *data), void *data) {
 	// Tiling

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -690,22 +690,22 @@ void workspace_detect_urgent(struct sway_workspace *workspace) {
 	}
 }
 
-static bool find_optimized_blur_iterator(struct sway_container *con, void *data) {
+static bool find_blurred_con_iterator(struct sway_container *con, void *data) {
 	struct sway_view *view = con->view;
 	if (!view) {
 		return false;
 	}
-	if (con->blur_enabled && !view->surface->opaque && (!container_is_floating(con) || config->blur_xray)) {
+	if (con->blur_enabled && !view->surface->opaque) {
 		return true;
 	}
 	return false;
 }
 
-bool should_workspace_need_optimized_blur(struct sway_workspace *ws) {
+bool should_workspace_have_blur(struct sway_workspace *ws) {
 	if (!workspace_is_visible(ws)) {
 		return false;
 	}
-	return (bool)workspace_find_container(ws, find_optimized_blur_iterator, NULL);
+	return (bool)workspace_find_container(ws, find_blurred_con_iterator, NULL);
 }
 
 void workspace_for_each_container(struct sway_workspace *ws,

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -695,10 +695,7 @@ static bool find_blurred_con_iterator(struct sway_container *con, void *data) {
 	if (!view) {
 		return false;
 	}
-	if (con->blur_enabled && !view->surface->opaque) {
-		return true;
-	}
-	return false;
+	return con->blur_enabled && !view->surface->opaque;
 }
 
 bool should_workspace_have_blur(struct sway_workspace *ws) {


### PR DESCRIPTION
This PR primarily moves the damage expansion for blur and shadows to the `output_damage_whole_container` function in `output.c`. This lets us clean up a lot of `render.c`.