### PR TITLE
flake: remove libinput patch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683048793,
-        "narHash": "sha256-XA1Y70qnX08eAYFfq4k9L1Bdu37+zm28B32w7d+155o=",
+        "lastModified": 1684585791,
+        "narHash": "sha256-lYPboblKrchmbkGMoAcAivomiOscZCjtGxxTSCY51SM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e4ad893057db74091ed0e3edf509a72fb83051df",
+        "rev": "eea79d584eff53bf7a76aeb63f8845da6d386129",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,18 @@
     in
     {
       overlays.default = final: prev: {
-        swayfx-unwrapped = prev.sway-unwrapped.overrideAttrs
-          (old: { src = builtins.path { path = prev.lib.cleanSource ./.; }; });
+        swayfx-unwrapped = prev.sway-unwrapped.overrideAttrs (old: {
+          src = builtins.path { path = prev.lib.cleanSource ./.; };
+          patches =
+            let
+              removePatches = [
+                "LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM.patch"
+              ];
+            in
+            builtins.filter
+              (patch: !builtins.elem (patch.name or null) removePatches)
+              (old.patches or [ ]);
+        });
       };
 
       packages = nixpkgs.lib.genAttrs targetSystems (system:


### PR DESCRIPTION
This was backported to SwayFX in 3c2e38b

I also updated the lock file.

Fixes #162