### PR TITLE
Fix toplevel borders

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -378,4 +378,6 @@ bool view_is_transient_for(struct sway_view *child, struct sway_view *ancestor);
 
 void view_assign_ctx(struct sway_view *view, struct launcher_ctx *ctx);
 
+bool gaps_to_edge(struct sway_view *view);
+
 #endif

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -727,7 +727,8 @@ static void render_view_toplevels(struct sway_view *view, struct sway_output *ou
 	clip_box.width = state.width;
 	clip_box.height = state.height;
 	if (state.fullscreen_mode == FULLSCREEN_NONE
-			&& (state.border == B_PIXEL || state.border == B_NORMAL)) {
+			&& (state.border == B_PIXEL || state.border == B_NORMAL)
+			&& config->hide_edge_borders_smart == ESMART_OFF) {
 		clip_box.x += state.border_thickness;
 		clip_box.y += state.border_thickness;
 		clip_box.width -= state.border_thickness * 2;

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -726,9 +726,14 @@ static void render_view_toplevels(struct sway_view *view, struct sway_output *ou
 	clip_box.y = state.y - output->ly;
 	clip_box.width = state.width;
 	clip_box.height = state.height;
+
+	bool smart = config->hide_edge_borders_smart == ESMART_ON ||
+		(config->hide_edge_borders_smart == ESMART_NO_GAPS &&
+		!gaps_to_edge(view));
+
 	if (state.fullscreen_mode == FULLSCREEN_NONE
 			&& (state.border == B_PIXEL || state.border == B_NORMAL)
-			&& config->hide_edge_borders_smart == ESMART_OFF) {
+			&& !smart) {
 		clip_box.x += state.border_thickness;
 		clip_box.y += state.border_thickness;
 		clip_box.width -= state.border_thickness * 2;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -233,7 +233,7 @@ static bool view_is_only_visible(struct sway_view *view) {
 	return true;
 }
 
-static bool gaps_to_edge(struct sway_view *view) {
+bool gaps_to_edge(struct sway_view *view) {
 	struct side_gaps gaps = view->container->pending.workspace->current_gaps;
 	return gaps.top > 0 || gaps.right > 0 || gaps.bottom > 0 || gaps.left > 0;
 }


### PR DESCRIPTION
I've added an additional check in `render_view_toplevels(...)` for the `smart_borders` setting to fix the issue with transparent borders on `smart_borders on` and `smart_borders no_gaps`.

This should fix some issues mentioned in #135.

It seems you have some plans for reworking the border rendering altogether but as of right now, this is a very simple fix.

Some similar logic is happening in `view_autoconfigure(...)` so maybe this can be done more elegantly but I don't have a deep enough understanding of the codebase to do this more gracefully (if that's currently possible).