### PR TITLE
Update stencil if the montior size changes

### DIFF
--- a/include/sway/desktop/fx_renderer/fx_framebuffer.h
+++ b/include/sway/desktop/fx_renderer/fx_framebuffer.h
@@ -5,12 +5,13 @@
 #include <stdbool.h>
 #include <wlr/types/wlr_output.h>
 
+#include "sway/desktop/fx_renderer/fx_stencilbuffer.h"
 #include "sway/desktop/fx_renderer/fx_texture.h"
 
 struct fx_framebuffer {
-	struct fx_texture texture;
 	GLuint fb;
-	GLuint stencil_buffer;
+	struct fx_stencilbuffer stencil_buffer;
+	struct fx_texture texture;
 };
 
 struct fx_framebuffer fx_framebuffer_create();
@@ -22,6 +23,5 @@ void fx_framebuffer_update(struct fx_framebuffer *buffer, int width, int height)
 void fx_framebuffer_add_stencil_buffer(struct fx_framebuffer *buffer, int width, int height);
 
 void fx_framebuffer_release(struct fx_framebuffer *buffer);
-
 
 #endif

--- a/include/sway/desktop/fx_renderer/fx_stencilbuffer.h
+++ b/include/sway/desktop/fx_renderer/fx_stencilbuffer.h
@@ -1,0 +1,18 @@
+#ifndef FX_STENCILBUFFER_H
+#define FX_STENCILBUFFER_H
+
+#include <GLES2/gl2.h>
+#include <stdbool.h>
+#include <wlr/render/wlr_texture.h>
+
+struct fx_stencilbuffer {
+	GLuint rb;
+	int width;
+	int height;
+};
+
+struct fx_stencilbuffer fx_stencilbuffer_create();
+
+void fx_stencilbuffer_release(struct fx_stencilbuffer *stencil_buffer);
+
+#endif

--- a/include/sway/desktop/fx_renderer/fx_texture.h
+++ b/include/sway/desktop/fx_renderer/fx_texture.h
@@ -13,6 +13,10 @@ struct fx_texture {
 	int height;
 };
 
-struct fx_texture fx_texture_from_wlr_texture(struct wlr_texture* tex);
+struct fx_texture fx_texture_create();
+
+struct fx_texture fx_texture_from_wlr_texture(struct wlr_texture *tex);
+
+void fx_texture_release(struct fx_texture *texture);
 
 #endif

--- a/sway/desktop/fx_renderer/fx_stencilbuffer.c
+++ b/sway/desktop/fx_renderer/fx_stencilbuffer.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <wlr/render/gles2.h>
+
+#include "sway/desktop/fx_renderer/fx_stencilbuffer.h"
+
+struct fx_stencilbuffer fx_stencilbuffer_create() {
+	return (struct fx_stencilbuffer) {
+		.rb = -1,
+		.width = -1,
+		.height = -1,
+	};
+}
+
+void fx_stencilbuffer_release(struct fx_stencilbuffer *stencil_buffer) {
+	if (stencil_buffer->rb != (uint32_t) -1 && stencil_buffer->rb) {
+		glDeleteRenderbuffers(1, &stencil_buffer->rb);
+	}
+	stencil_buffer->rb = -1;
+	stencil_buffer->width = -1;
+	stencil_buffer->height = -1;
+}

--- a/sway/desktop/fx_renderer/fx_texture.c
+++ b/sway/desktop/fx_renderer/fx_texture.c
@@ -3,7 +3,16 @@
 
 #include "sway/desktop/fx_renderer/fx_texture.h"
 
-struct fx_texture fx_texture_from_wlr_texture(struct wlr_texture* texture) {
+struct fx_texture fx_texture_create() {
+	return (struct fx_texture) {
+		.id = 0,
+		.target = 0,
+		.width = -1,
+		.height = -1,
+	};
+}
+
+struct fx_texture fx_texture_from_wlr_texture(struct wlr_texture *texture) {
 	assert(wlr_texture_is_gles2(texture));
 
 	struct wlr_gles2_texture_attribs texture_attrs;
@@ -16,4 +25,13 @@ struct fx_texture fx_texture_from_wlr_texture(struct wlr_texture* texture) {
 		.width = texture->width,
 		.height = texture->height,
 	};
+}
+
+void fx_texture_release(struct fx_texture *texture) {
+	if (texture->id) {
+		glDeleteTextures(1, &texture->id);
+	}
+	texture->id = 0;
+	texture->width = -1;
+	texture->height = -1;
 }

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -17,6 +17,7 @@ sway_sources = files(
 	'desktop/desktop.c',
 	'desktop/fx_renderer/fx_framebuffer.c',
 	'desktop/fx_renderer/fx_renderer.c',
+	'desktop/fx_renderer/fx_stencilbuffer.c',
 	'desktop/fx_renderer/fx_texture.c',
 	'desktop/fx_renderer/matrix.c',
 	'desktop/idle_inhibit_v1.c',


### PR DESCRIPTION
Fixes a issue where the stencil wouldn't update its size when the monitor size changes. Most visible when running a nested session and resizing said session