### PR TITLE
fix: crash when splitting inside tabbed container

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1454,7 +1454,7 @@ static void render_containers_tabbed(struct sway_output *output,
 
 	struct decoration_data deco_data = {
 		.alpha = current->alpha,
-		.dim_color = view_is_urgent(current->view)
+		.dim_color = current->view && view_is_urgent(current->view)
 				? config->dim_inactive_colors.urgent
 				: config->dim_inactive_colors.unfocused,
 		.dim = current->current.focused || parent->focused ? 0.0f : current->dim,


### PR DESCRIPTION
Fixes issue discussed in comments of #177.