### PR TITLE
fix: crash when moving tabbed container to scratchpad

### DIFF
--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -57,12 +57,15 @@ void root_destroy(struct sway_root *root) {
 
 /* Set minimized state from scratchpad container `show` state */
 static void root_scratchpad_set_minimize(struct sway_container *con, bool minimize) {
-	struct wlr_foreign_toplevel_handle_v1 *foreign_toplevel = con->view->foreign_toplevel;
-	if (wlr_surface_is_xwayland_surface(con->view->surface)) {
-		struct wlr_xwayland_surface *xsurface = wlr_xwayland_surface_from_wlr_surface(con->view->surface);
-		wlr_xwayland_surface_set_minimized(xsurface, minimize);
-	} else if (foreign_toplevel) {
-		wlr_foreign_toplevel_handle_v1_set_minimized(foreign_toplevel, minimize);
+	if (con->view) {
+		struct wlr_foreign_toplevel_handle_v1 *foreign_toplevel = con->view->foreign_toplevel;
+
+		if (wlr_surface_is_xwayland_surface(con->view->surface)) {
+			struct wlr_xwayland_surface *xsurface = wlr_xwayland_surface_from_wlr_surface(con->view->surface);
+			wlr_xwayland_surface_set_minimized(xsurface, minimize);
+		} else if (foreign_toplevel) {
+			wlr_foreign_toplevel_handle_v1_set_minimized(foreign_toplevel, minimize);
+		}
 	}
 }
 


### PR DESCRIPTION
when `scratchpad_minimize` enabled

fixes #177 