### PR TITLE
fix: consider dim introduced transparency for blur

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -441,7 +441,7 @@ static void render_surface_iterator(struct sway_output *output,
 		pixman_region32_init(&opaque_region);
 
 		bool has_alpha = false;
-		if (deco_data.alpha < 1.0) {
+		if (deco_data.alpha < 1.0 || deco_data.dim_color[3] < 1.0) {
 			has_alpha = true;
 			pixman_region32_union_rect(&opaque_region, &opaque_region, 0, 0, 0, 0);
 		} else {


### PR DESCRIPTION
The blur rendering logic includes the optimization to render blur only for transparent surfaces. This patch considers surfaces as transparent also when the transparency is only introduced by the dim color.

We can now have windows, that are opaque by default become transparent with blurred background as soon as they loose focus.

Example configuration:

```
blur on
blur_passes 3
blur_radius 5

default_dim_inactive 0.15
dim_inactive_colors.unfocused #00000000
```

![screenshot-20230604210154](https://github.com/WillPower3309/swayfx/assets/80712/5f269c15-11e2-46b9-bea9-5db80d309944)
