### PR TITLE
fix: crash when moving to scratchpad tiled window

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1399,6 +1399,10 @@ static void render_containers_linear(struct sway_output *output,
 	for (int i = 0; i < parent->children->length; ++i) {
 		struct sway_container *child = parent->children->items[i];
 
+		if (container_is_scratchpad_hidden(child)) {
+			continue;
+		}
+
 		if (child->view) {
 			struct sway_view *view = child->view;
 			struct border_colors *colors;


### PR DESCRIPTION
After #171 swayfx started segfaulting on me when moving a tiled window to the scratchpad. After taking a look at the code, I decided it was better if we didn't render a container that was going away to the scratchpad anyway, therefore also avoiding the NULL-dereferencing that was happening inside `gaps_to_edge()` that led to the segfault.

If you want to reproduce the bug that is currently present in master, you can try just moving a tiled window to the scratchpad. It isn't always triggered, but the possibility that it is triggered increases the more windows you have open in your workspace.

I've tested this PR on my machines, so far so good.