### PR TITLE
Removed systemd requirement in both AUR PKGBUILDs

### DIFF
--- a/build-scripts/aur-git/PKGBUILD
+++ b/build-scripts/aur-git/PKGBUILD
@@ -59,7 +59,6 @@ pkgver() {
 
 build() {
 	arch-meson \
-		-Dsd-bus-provider=libsystemd \
 		-Dwerror=false \
 		"$_pkgname" build
 	meson compile -C build

--- a/build-scripts/aur/PKGBUILD
+++ b/build-scripts/aur/PKGBUILD
@@ -54,7 +54,6 @@ install=sway.install
 
 build() {
 	arch-meson \
-		-Dsd-bus-provider=libsystemd \
 		-Dwerror=false \
 		"${_pkgname}-${pkgver}" build
 	meson compile -C build


### PR DESCRIPTION
Fixes issues building swayfx on non-systemd Arch-based distros