### PR TITLE
feat: add shadow color for inactive windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Sway is an incredible window manager, and certainly one of the most well establi
     - `shadows_on_csd enable|disable` (**Note**: The shadow might not fit some windows)
     - `shadow_blur_radius <integer value 0 - 100>`
     - `shadow_color <hex color with alpha> ex, #0000007F`
+    - `shadow_inactive_color <hex color with alpha> ex, #0000007F`
 + LayerShell effects (to blur panels / notifications etc):
     - `layer_effects <layer namespace> <effects>`
     - The current layer namespaces can be shown with `swaymsg -r -t get_outputs | jq '.[0].layer_shell_surfaces | .[] | .namespace'`

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -192,6 +192,7 @@ sway_cmd cmd_set;
 sway_cmd cmd_shortcuts_inhibitor;
 sway_cmd cmd_shadow_blur_radius;
 sway_cmd cmd_shadow_color;
+sway_cmd cmd_shadow_inactive_color;
 sway_cmd cmd_shadows;
 sway_cmd cmd_shadows_on_csd;
 sway_cmd cmd_show_marks;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -492,6 +492,7 @@ struct sway_config {
 	bool shadows_on_csd_enabled;
 	int shadow_blur_sigma;
 	float shadow_color[4];
+	float shadow_inactive_color[4];
 
 	bool blur_enabled;
 	bool blur_xray;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -96,6 +96,7 @@ static const struct cmd_handler handlers[] = {
 	{ "set", cmd_set },
 	{ "shadow_blur_radius", cmd_shadow_blur_radius },
 	{ "shadow_color", cmd_shadow_color },
+	{ "shadow_inactive_color", cmd_shadow_inactive_color },
 	{ "shadows", cmd_shadows },
 	{ "shadows_on_csd", cmd_shadows_on_csd },
 	{ "show_marks", cmd_show_marks },

--- a/sway/commands/shadow_color.c
+++ b/sway/commands/shadow_color.c
@@ -17,8 +17,9 @@ struct cmd_results *cmd_shadow_color(int argc, char **argv) {
 		return cmd_results_new(CMD_INVALID, "Invalid %s color %s",
 				"shadow_color", argv[0]);
 	}
-	if (!memcmp(config->shadow_color, config->shadow_inactive_color, sizeof(config->shadow_color)))
+	if (memcmp(config->shadow_color, config->shadow_inactive_color, sizeof(config->shadow_color)) == 0) {
 		color_to_rgba(config->shadow_inactive_color, color);
+	}
 	color_to_rgba(config->shadow_color, color);
 
 	arrange_root();

--- a/sway/commands/shadow_inactive_color.c
+++ b/sway/commands/shadow_inactive_color.c
@@ -6,20 +6,18 @@
 #include "sway/tree/container.h"
 #include "util.h"
 
-struct cmd_results *cmd_shadow_color(int argc, char **argv) {
+struct cmd_results *cmd_shadow_inactive_color(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "shadow_color", EXPECTED_AT_LEAST, 1))) {
+	if ((error = checkarg(argc, "shadow_inactive_color", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
 
 	uint32_t color;
 	if (!parse_color(argv[0], &color)) {
 		return cmd_results_new(CMD_INVALID, "Invalid %s color %s",
-				"shadow_color", argv[0]);
+				"shadow_inactive_color", argv[0]);
 	}
-	if (!memcmp(config->shadow_color, config->shadow_inactive_color, sizeof(config->shadow_color)))
-		color_to_rgba(config->shadow_inactive_color, color);
-	color_to_rgba(config->shadow_color, color);
+	color_to_rgba(config->shadow_inactive_color, color);
 
 	arrange_root();
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -352,6 +352,7 @@ static void config_defaults(struct sway_config *config) {
 	config->shadows_on_csd_enabled = false;
 	config->shadow_blur_sigma = 20.0f;
 	color_to_rgba(config->shadow_color, 0x0000007F);
+	color_to_rgba(config->shadow_inactive_color, 0x0000007F);
 
 	config->blur_enabled = false;
 	config->blur_xray = false;

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -884,7 +884,9 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 		scale_box(&box, output_scale);
 		int scaled_corner_radius = deco_data.corner_radius == 0 ?
 				0 : (deco_data.corner_radius + state->border_thickness) * output_scale;
-		render_box_shadow(output, damage, &box, config->shadow_color, config->shadow_blur_sigma,
+		float* shadow_color = view_is_urgent(view) || state->focused ?
+				config->shadow_color : config->shadow_inactive_color;
+		render_box_shadow(output, damage, &box, shadow_color, config->shadow_blur_sigma,
 				scaled_corner_radius);
 	}
 

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -123,6 +123,7 @@ sway_sources = files(
 	'commands/set.c',
 	'commands/shadow_blur_radius.c',
 	'commands/shadow_color.c',
+	'commands/shadow_inactive_color.c',
 	'commands/shadows.c',
 	'commands/shadows_on_csd.c',
 	'commands/show_marks.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -686,6 +686,9 @@ The default colors are:
 *shadow_color* <hex color with alpha>
 	The shadow color. Default color: #0000007F
 
+*shadow_inactive_color* <hex color with alpha>
+	The shadow color for inactive windows. Default value: *shadow_color*
+
 *blur* enable|disable
 	Sets whether blur should be drawn. Can also be set per window with
 	*for_window*.


### PR DESCRIPTION
Solves #228.

This pull request adds a configuration option for changing the inactive windows' shadow color, `shadow_inactive_color`. It follows the same syntax as `shadow_color`. If it is not defined, it takes the default value of `shadow_color`, there is no change for existing configurations.

This is my first time contributing to this project and one of my first pull requests, so please if there is anything I have to do differently or change tell me. (Also thank you, I have been using this as my main desktop and couldn't be happier!)

https://github.com/WillPower3309/swayfx/assets/22449369/c7d83b78-73fa-4aa6-a1e0-406eb20c48a4