### PR TITLE
fix(PKGBUILD): support new portals req for XDG_CURRENT_DESKTOP

### DIFF
--- a/build-scripts/aur-git/50-systemd-user.conf
+++ b/build-scripts/aur-git/50-systemd-user.conf
@@ -2,6 +2,15 @@
 # See FS#63021
 # Adapted from xorg's 50-systemd-user.sh, which achieves a similar goal.
 
-exec systemctl --user import-environment DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP
+# Upstream refuses to set XDG_CURRENT_DESKTOP so we have to.
+exec systemctl --user set-environment XDG_CURRENT_DESKTOP=sway
+exec systemctl --user import-environment DISPLAY \
+                                         SWAYSOCK \
+                                         WAYLAND_DISPLAY \
+                                         XDG_CURRENT_DESKTOP
+
 exec hash dbus-update-activation-environment 2>/dev/null && \
-     dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP
+     dbus-update-activation-environment --systemd DISPLAY \
+                                                  SWAYSOCK \
+                                                  XDG_CURRENT_DESKTOP=sway \
+                                                  WAYLAND_DISPLAY

--- a/build-scripts/aur-git/PKGBUILD
+++ b/build-scripts/aur-git/PKGBUILD
@@ -2,7 +2,7 @@
 _pkgname=swayfx
 pkgname="$_pkgname-git"
 pkgver=r7023.9cd02fc4
-pkgrel=3
+pkgrel=4
 license=("MIT")
 pkgdesc="SwayFX: Sway, but with eye candy!"
 makedepends=(
@@ -37,15 +37,19 @@ optdepends=(
 	"swaylock: Screen locker"
 	"wallutils: Timed wallpapers"
 	"waybar: Highly customizable bar"
+	"xdg-desktop-portal-gtk: Default xdg-desktop-portal for file picking"
+	"xdg-desktop-portal-wlr: xdg-desktop-portal backend"
 )
 backup=(etc/sway/config)
 arch=("i686" "x86_64")
 url="https://github.com/WillPower3309/swayfx"
 source=("${pkgname%-*}::git+${url}.git"
-	50-systemd-user.conf)
+	50-systemd-user.conf
+	sway-portals.conf)
 sha512sums=(
 	"SKIP"
-	"c2b7d808f4231f318e03789015624fd4cf32b81434b15406570b4e144c0defc54e216d881447e6fd9fc18d7da608cccb61c32e0e1fab2f1fe2750acf812d3137")
+	"d5f9aadbb4bbef067c31d4c8c14dad220eb6f3e559e9157e20e1e3d47faf2f77b9a15e52519c3ffc53dc8a5202cb28757b81a4b3b0cc5dd50a4ddc49e03fe06e"
+	"790741df028822bf4d83170dea57e1c63f7d7938cf31969e4cd347b0fc07330322b603c9ec0091b7a3f425132bed9dee6f261074cc273555120858beaaaf5da1")
 provides=("sway" "swayfx")
 conflicts=("sway" "swayfx")
 options=(debug)
@@ -67,6 +71,7 @@ build() {
 
 package() {
 	install -Dm644 50-systemd-user.conf -t "$pkgdir/etc/sway/config.d/"
+	install -Dm644 sway-portals.conf "$pkgdir/usr/share/xdg-desktop-portal/sway-portals.conf"
 
 	DESTDIR="$pkgdir" meson install -C build
 

--- a/build-scripts/aur-git/sway-portals.conf
+++ b/build-scripts/aur-git/sway-portals.conf
@@ -1,0 +1,6 @@
+[preferred]
+# Use xdg-desktop-portal-gtk for every portal interface...
+default=gtk
+# ... except for the ScreenCast and Screenshot
+org.freedesktop.impl.portal.ScreenCast=wlr
+org.freedesktop.impl.portal.Screenshot=wlr

--- a/build-scripts/aur/50-systemd-user.conf
+++ b/build-scripts/aur/50-systemd-user.conf
@@ -2,6 +2,15 @@
 # See FS#63021
 # Adapted from xorg's 50-systemd-user.sh, which achieves a similar goal.
 
-exec systemctl --user import-environment DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP
+# Upstream refuses to set XDG_CURRENT_DESKTOP so we have to.
+exec systemctl --user set-environment XDG_CURRENT_DESKTOP=sway
+exec systemctl --user import-environment DISPLAY \
+                                         SWAYSOCK \
+                                         WAYLAND_DISPLAY \
+                                         XDG_CURRENT_DESKTOP
+
 exec hash dbus-update-activation-environment 2>/dev/null && \
-     dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP
+     dbus-update-activation-environment --systemd DISPLAY \
+                                                  SWAYSOCK \
+                                                  XDG_CURRENT_DESKTOP=sway \
+                                                  WAYLAND_DISPLAY

--- a/build-scripts/aur/PKGBUILD
+++ b/build-scripts/aur/PKGBUILD
@@ -2,7 +2,7 @@
 _pkgname=swayfx
 pkgname="$_pkgname"
 pkgver=0.3.2
-pkgrel=3
+pkgrel=4
 license=("MIT")
 pkgdesc="SwayFX: Sway, but with eye candy!"
 makedepends=(
@@ -37,15 +37,19 @@ optdepends=(
 	"swaylock: Screen locker"
 	"wallutils: Timed wallpapers"
 	"waybar: Highly customizable bar"
+	"xdg-desktop-portal-gtk: Default xdg-desktop-portal for file picking"
+	"xdg-desktop-portal-wlr: xdg-desktop-portal backend"
 )
 backup=(etc/sway/config)
 arch=("i686" "x86_64")
 url="https://github.com/WillPower3309/swayfx"
 source=("${_pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/$pkgver.tar.gz"
-	50-systemd-user.conf)
+	50-systemd-user.conf
+	sway-portals.conf)
 sha512sums=(
 	"SKIP"
-	"c2b7d808f4231f318e03789015624fd4cf32b81434b15406570b4e144c0defc54e216d881447e6fd9fc18d7da608cccb61c32e0e1fab2f1fe2750acf812d3137")
+	"d5f9aadbb4bbef067c31d4c8c14dad220eb6f3e559e9157e20e1e3d47faf2f77b9a15e52519c3ffc53dc8a5202cb28757b81a4b3b0cc5dd50a4ddc49e03fe06e"
+	"790741df028822bf4d83170dea57e1c63f7d7938cf31969e4cd347b0fc07330322b603c9ec0091b7a3f425132bed9dee6f261074cc273555120858beaaaf5da1")
 provides=("sway" "swayfx")
 conflicts=("sway" "swayfx")
 options=(debug)
@@ -62,6 +66,7 @@ build() {
 
 package() {
 	install -Dm644 50-systemd-user.conf -t "$pkgdir/etc/sway/config.d/"
+	install -Dm644 sway-portals.conf "$pkgdir/usr/share/xdg-desktop-portal/sway-portals.conf"
 
 	DESTDIR="$pkgdir" meson install -C build
 

--- a/build-scripts/aur/sway-portals.conf
+++ b/build-scripts/aur/sway-portals.conf
@@ -1,0 +1,6 @@
+[preferred]
+# Use xdg-desktop-portal-gtk for every portal interface...
+default=gtk
+# ... except for the ScreenCast and Screenshot
+org.freedesktop.impl.portal.ScreenCast=wlr
+org.freedesktop.impl.portal.Screenshot=wlr


### PR DESCRIPTION
Integrates commits [c85a455e](https://gitlab.archlinux.org/archlinux/packaging/packages/sway/-/commit/c85a455eb653256b57b0b1661e398a48946e85b4) and [2f9c63b0](https://gitlab.archlinux.org/archlinux/packaging/packages/sway/-/commit/2f9c63b0539119acb63d6028c61d41c7faa1cebb) from extra/sway.

Copied from c85a455e:

> As of version 1.17, xdg-desktop-portal requires desktops to declare
> which portals should be used. For Sway, this requires a file
> /usr/share/xdg-desktop-portal/sway-portals.conf (or a local user
> config).
>
> A reasonable default is to use GTK for the file picker (as wlr doesn't
> have file picker support) and wlr for screencast/screenshot support.
> Fedora does this similarly. [1]
>
> Upstream is not interested in shipping a configuration file [2] so we
> need to do it downstream.
>
> [1] https://src.fedoraproject.org/rpms/sway/blob/rawhide/f/sway-portals.conf
> [2] https://github.com/swaywm/sway/issues/7773