### PR TITLE
fix: aur build failed: sd-bus-provider set to auto

### DIFF
--- a/build-scripts/aur-git/PKGBUILD
+++ b/build-scripts/aur-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Erik Reider <erik.reider@protonmail.com>
 _pkgname=swayfx
 pkgname="$_pkgname-git"
-pkgver=r6930.94ebb45e
+pkgver=r7023.9cd02fc4
 pkgrel=1
 license=("MIT")
 pkgdesc="SwayFX: Sway, but with eye candy!"
@@ -60,6 +60,7 @@ build() {
 	export PKG_CONFIG_PATH='/usr/lib/wlroots0.16/pkgconfig'
 	arch-meson \
 		-Dwerror=false \
+		-Dsd-bus-provider=libsystemd \
 		"$_pkgname" build
 	meson compile -C build
 }

--- a/build-scripts/aur/PKGBUILD
+++ b/build-scripts/aur/PKGBUILD
@@ -55,6 +55,7 @@ build() {
 	export PKG_CONFIG_PATH='/usr/lib/wlroots0.16/pkgconfig'
 	arch-meson \
 		-Dwerror=false \
+		-Dsd-bus-provider=libsystemd \
 		"${_pkgname}-${pkgver}" build
 	meson compile -C build
 }


### PR DESCRIPTION
> swayfx/meson.build:92:2: ERROR: Assert failed: sd-bus-provider must
not be set to auto since auto_features != auto