### PR TITLE
enhancement: update version printing format

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -178,6 +178,7 @@ if git.found()
 	endif
 endif
 add_project_arguments('-DSWAY_VERSION=@0@'.format(version), language: 'c')
+add_project_arguments('-DSWAY_ORIGINAL_VERSION="1.8.1"', language: 'c')
 
 # Compute the relative path used by compiler invocations.
 source_root = meson.current_source_dir().split('/')

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -209,6 +209,7 @@ json_object *ipc_json_get_version(void) {
 	sscanf(SWAY_VERSION, "%d.%d.%d", &major, &minor, &patch);
 
 	json_object_object_add(version, "human_readable", json_object_new_string(SWAY_VERSION));
+	json_object_object_add(version, "sway_original_version", json_object_new_string(SWAY_ORIGINAL_VERSION));
 	json_object_object_add(version, "variant", json_object_new_string("sway"));
 	json_object_object_add(version, "major", json_object_new_int(major));
 	json_object_object_add(version, "minor", json_object_new_int(minor));

--- a/sway/main.c
+++ b/sway/main.c
@@ -373,7 +373,8 @@ int main(int argc, char **argv) {
 	// prevent ipc from crashing sway
 	signal(SIGPIPE, SIG_IGN);
 
-	sway_log(SWAY_INFO, "Starting swayfx version " SWAY_VERSION " (based on sway version " SWAY_ORIGINAL_VERSION ")");
+	sway_log(SWAY_INFO, "Starting swayfx version " SWAY_VERSION
+			" (based on sway version " SWAY_ORIGINAL_VERSION ")");
 
 	root = root_create();
 

--- a/sway/main.c
+++ b/sway/main.c
@@ -288,7 +288,7 @@ int main(int argc, char **argv) {
 			allow_unsupported_gpu = true;
 			break;
 		case 'v': // version
-			printf("sway version " SWAY_VERSION "\n");
+			printf("swayfx version " SWAY_VERSION " (based on sway " SWAY_ORIGINAL_VERSION ")\n");
 			exit(EXIT_SUCCESS);
 			break;
 		case 'V': // verbose
@@ -335,7 +335,7 @@ int main(int argc, char **argv) {
 		wlr_log_init(WLR_ERROR, handle_wlr_log);
 	}
 
-	sway_log(SWAY_INFO, "Sway version " SWAY_VERSION);
+	sway_log(SWAY_INFO, "swayfx version " SWAY_VERSION " (based on sway version " SWAY_ORIGINAL_VERSION ")");
 	sway_log(SWAY_INFO, "wlroots version " WLR_VERSION_STR);
 	log_kernel();
 	log_distro();
@@ -373,7 +373,7 @@ int main(int argc, char **argv) {
 	// prevent ipc from crashing sway
 	signal(SIGPIPE, SIG_IGN);
 
-	sway_log(SWAY_INFO, "Starting sway version " SWAY_VERSION);
+	sway_log(SWAY_INFO, "Starting swayfx version " SWAY_VERSION " (based on sway version " SWAY_ORIGINAL_VERSION ")");
 
 	root = root_create();
 

--- a/swaybar/main.c
+++ b/swaybar/main.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
 			swaybar.id = strdup(optarg);
 			break;
 		case 'v':
-			printf("swaybar version " SWAY_VERSION "\n");
+			printf("swaybar version " SWAY_VERSION " (based on sway " SWAY_ORIGINAL_VERSION ")\n");
 			exit(EXIT_SUCCESS);
 			break;
 		case 'd': // Debug

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -294,9 +294,11 @@ static void pretty_print_output(json_object *o) {
 }
 
 static void pretty_print_version(json_object *v) {
-	json_object *ver;
-	json_object_object_get_ex(v, "human_readable", &ver);
-	printf("sway version %s\n", json_object_get_string(ver));
+	json_object *swayfx_ver;
+	json_object *sway_ver;
+	json_object_object_get_ex(v, "human_readable", &swayfx_ver);
+	json_object_object_get_ex(v, "sway_original_version", &sway_ver);
+	printf("swayfx version %s (based on sway %s)\n", json_object_get_string(swayfx_ver), json_object_get_string(sway_ver));
 }
 
 static void pretty_print_config(json_object *c) {
@@ -470,7 +472,7 @@ int main(int argc, char **argv) {
 			cmdtype = strdup(optarg);
 			break;
 		case 'v':
-			printf("swaymsg version " SWAY_VERSION "\n");
+			printf("swaymsg version " SWAY_VERSION " (based on sway " SWAY_ORIGINAL_VERSION ")\n");
 			exit(EXIT_SUCCESS);
 			break;
 		default:

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -298,7 +298,8 @@ static void pretty_print_version(json_object *v) {
 	json_object *sway_ver;
 	json_object_object_get_ex(v, "human_readable", &swayfx_ver);
 	json_object_object_get_ex(v, "sway_original_version", &sway_ver);
-	printf("swayfx version %s (based on sway %s)\n", json_object_get_string(swayfx_ver), json_object_get_string(sway_ver));
+	printf("swayfx version %s (based on sway %s)\n",
+			json_object_get_string(swayfx_ver), json_object_get_string(sway_ver));
 }
 
 static void pretty_print_config(json_object *c) {

--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -278,7 +278,7 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 			}
 			break;
 		case 'v': // Version
-			printf("swaynag version " SWAY_VERSION "\n");
+			printf("swaynag version " SWAY_VERSION " (based on sway " SWAY_ORIGINAL_VERSION ")\n");
 			return -1;
 		case TO_COLOR_BACKGROUND: // Background color
 			if (type && !parse_color(optarg, &type->background)) {


### PR DESCRIPTION
as mentioned in #253, version numbers can be confusing if you don't know
or realize you're running SwayFX instead of standard sway.

to fix this issue, I've updated the way we display versions, replacing
"sway version X" to "swayfx version X", suffixed by the sway upstream
version which swayfx is based upon.

while not immediately displaying we come from swayfx in
swaymsg/swaynag/swaybar, we do display we're based off a specific
upstream sway version.

note: this requires updating `meson.build` (currently `meson.build:181`)
each time we rebase into a new sway version.

Closes: Issue #253
