### PR TITLE
Keep cursor active when hidden

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -257,7 +257,6 @@ void cursor_update_image(struct sway_cursor *cursor,
 static void cursor_hide(struct sway_cursor *cursor) {
 	wlr_cursor_set_image(cursor->cursor, NULL, 0, 0, 0, 0, 0, 0);
 	cursor->hidden = true;
-	wlr_seat_pointer_notify_clear_focus(cursor->seat->wlr_seat);
 }
 
 static int hide_notify(void *data) {


### PR DESCRIPTION
Resolves this issue: https://github.com/swaywm/sway/issues/6297
And kinda resolves this one, too: https://github.com/swaywm/sway/issues/7853

This was [denied](https://github.com/swaywm/sway/issues/6297#issuecomment-1403866816) in vanilla sway because ["Invisible-but-still-active cursors are confusing."](https://github.com/swaywm/sway/issues/4145#issuecomment-491880044) (I don't see how).

This not only would fix gaming when using `hide_cursor when-typing`, but it will also let you hover for a preview and have it not "despawn" after the timeout.

For example: if you read a Wikipedia page, there are links to other articles that you can hover over to show a preview for; problem is, when using `hide_cursor [timeout]`, the preview goes away when the cursor hides since the cursor also "deactivates". This is extremely annoying.

Here are some links to Reddit of people complaining about `hide_cursor`'s current behavior:
https://www.reddit.com/r/swaywm/comments/10kevqd/avoid_using_the_option_hide_cursor_whentyping_by
https://www.reddit.com/r/swaywm/comments/n7m5d2/a_script_to_disable_hide_cursor_whentyping_when

I've been using this patch for a couple of days now and everything works fine. It's only a sloc change.