### PR TITLE
Overhaul nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,28 +1,12 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684585791,
-        "narHash": "sha256-lYPboblKrchmbkGMoAcAivomiOscZCjtGxxTSCY51SM=",
+        "lastModified": 1712192574,
+        "narHash": "sha256-LbbVOliJKTF4Zl2b9salumvdMXuQBr2kuKP5+ZwbYq4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eea79d584eff53bf7a76aeb63f8845da6d386129",
+        "rev": "f480f9d09e4b4cf87ee6151eba068197125714de",
         "type": "github"
       },
       "original": {
@@ -34,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,73 +1,65 @@
 {
-  description = "swaywm development environment";
-
-  inputs = {
-    flake-compat = {
-      url = "github:edolstra/flake-compat";
-      flake = false;
-    };
-
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-  };
-
-  outputs = { self, nixpkgs, flake-compat, ... }:
+  description = "Swayfx development environment";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  outputs =
+    { self, nixpkgs, ... }:
     let
-      pkgsFor = system:
-        import nixpkgs {
-          inherit system;
-          overlays = [ ];
-        };
-
-      targetSystems = [ "aarch64-linux" "x86_64-linux" ];
+      pkgsFor = system: import nixpkgs { inherit system; };
+      targetSystems = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
     in
     {
-      overlays.default = final: prev: {
-        swayfx-unwrapped = prev.sway-unwrapped.overrideAttrs (old: {
-          src = builtins.path { path = prev.lib.cleanSource ./.; };
-          patches =
-            let
-              removePatches = [
-                "LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM.patch"
-              ];
-            in
-            builtins.filter
-              (patch: !builtins.elem (patch.name or null) removePatches)
-              (old.patches or [ ]);
-        });
-      };
+      overlays.default = _: prev: { swayfx-unwrapped = self.packages.${prev.system}.swayfx-unwrapped; };
 
-      packages = nixpkgs.lib.genAttrs targetSystems (system:
-        let pkgs = pkgsFor system;
-        in (self.overlays.default pkgs pkgs) // {
-          default = self.packages.${system}.swayfx-unwrapped;
-        });
+      packages = nixpkgs.lib.genAttrs targetSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        rec {
+          swayfx-unwrapped =
+            (pkgs.swayfx-unwrapped.override {
+              # When the sway 1.9 rebase is finished, this will need to be overridden.
+              # wlroots_0_16 = pkgs.wlroots_0_16;
+            }).overrideAttrs
+              (old: {
+                version = "0.3.2-git";
+                src = pkgs.lib.cleanSource ./.;
+              });
+          default = swayfx-unwrapped;
+        }
+      );
 
-      devShells = nixpkgs.lib.genAttrs targetSystems (system:
+      devShells = nixpkgs.lib.genAttrs targetSystems (
+        system:
         let
           pkgs = pkgsFor system;
         in
         {
           default = pkgs.mkShell {
             name = "swayfx-shell";
-            depsBuildBuild = with pkgs; [ pkg-config ];
-            inputsFrom = [ self.packages.${system}.swayfx-unwrapped pkgs.wlroots_0_16 ];
-
+            inputsFrom = [
+              self.packages.${system}.swayfx-unwrapped
+              pkgs.wlroots_0_16
+            ];
             nativeBuildInputs = with pkgs; [
               cmake
-              meson
-              ninja
-              pkg-config
               wayland-scanner
-              scdoc
-              hwdata # for wlroots
             ];
-
-            shellHook = with pkgs; ''(
-              mkdir -p "$PWD/subprojects"
-              cd "$PWD/subprojects"
-              cp -R --no-preserve=mode,ownership ${wlroots_0_16.src} wlroots
-            )'';
+            # Copy the nix version of wlroots into the project
+            shellHook = with pkgs; ''
+              (
+                mkdir -p "$PWD/subprojects" && cd "$PWD/subprojects"
+                cp -R --no-preserve=mode,ownership ${wlroots_0_16.src} wlroots
+              )'';
           };
-        });
+        }
+      );
+
+      formatter = nixpkgs.lib.genAttrs targetSystems (system: {
+        default = (pkgsFor system).nixfmt-rfc-style;
+      });
     };
 }


### PR DESCRIPTION
## Flake overhaul

I'm still new to nix, so if I made any incorrect assumptions just let me know!

- Updated flake.lock
- Allow using both the override and insert overlay strategies, keep the previous default (override)
- Cleanup extra devshell packages (duplicates already included by inputsFrom)
- Remove flake-compat input (hasnt been fully setup afaik)
- Revert libinput patch filter
- Define a `nix fmt` utility for the flake, I went with the newly released `nixpkgs-rfc-style` 

## Explanation 

Trying to use the current flake overlay with a nixos flake on a recent unstable revision wreaks some havoc, due to the newer nixpkgs.sway-unwrapped using wlroots 0.17. The way the overlay is currently implemented, the package can break due to it just being an override of whatever parent nixpkgs is passed in. An alternative way would be to define the package output directly using the locked nixpkgs, and the overlay can just insert the locked working version into the users nixpkgs. We can offer both strategies, for whichever users need more. This pattern also seems to be provided by the popular flake-parts nix library, under their "overlay for free", so I assume it's a popular flow.

Flake-compat input should be removed since the repository doesn't have a default.nix to expose it, and nobody could use this repo as a non flake anyway (AFAIK)

Updated nixpkgs no longer uses the libinput patch, so it should be safe to remove.

## Example usage of the new insert overlay

[Use the overlay to insert to any nixpkgs](https://github.com/ozwaldorf/flake/blob/2006aed68cec91115663cd7a530c9bbd6df40258/flake.nix#L63):

```nix
pkgs = import nixpkgs { 
  inherit system;
  overlays = [ inputs.swayfx.overlays.insert ];
};
```

[Enable swayfx, using the sway module (unstable)](https://github.com/ozwaldorf/flake/blob/2006aed68cec91115663cd7a530c9bbd6df40258/flake.nix#L63):

```nix
programs.swayfx = {
  enable = true;
  package = pkgs.swayfx;
};
```

Or, as a workaround for the current stable nixpkgs:

```nix
programs.swayfx = {
  enable = true;
  package = pkgs.sway.override { 
    sway-unwrapped = pkgs.swayfx-unwrapped;
  };
};
```

## Testing

Passes [garnix](https://garnix.io) ci on my fork: https://github.com/ozwaldorf/swayfx/runs/23469316022. On a side note, it might be worth considering enabling on this project