### PR TITLE
fix: Changed outputs; `nix flake show` now completes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,8 +60,6 @@
         }
       );
 
-      formatter = nixpkgs.lib.genAttrs targetSystems (system: {
-        default = (pkgsFor system).nixfmt-rfc-style;
-      });
+      formatter = nixpkgs.lib.genAttrs targetSystems (system: (pkgsFor system).nixfmt-rfc-style);
     };
 }


### PR DESCRIPTION
Removed the `default` attribute from `outputs.formatter.<system>`, instead parse the formatter derivation directly.

This fixes the issue that `nix flake show` doesn't complete.