### PR TITLE
flake: switch default overlay to insert for wider compatibility

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
     in
     {
       overlays = rec {
-        default = override;
+        default = insert;
         # Override onto the input nixpkgs
         override = _: prev: mkPackage prev;
         # Insert using the locked nixpkgs


### PR DESCRIPTION
The changes in #279 added the insert overlay, which can be used with any nixpkgs and always work, since it uses the locked nixpkgs instead of the previous overlay. We now have switched to the breaking changes in unstable nixpkgs, so users of the stable nixpkgs and default overlay get some errors when upgrading, as seen in #281. Because of this, it might be better to set the default overlay to insert for better out of the box compatibility for the majority of users. Advanced users of course can still opt into using the override flake, given they are on a compatible nixpkgs version and know what they are doing

> [Passing CI run](https://github.com/ozwaldorf/swayfx/runs/23721473299)