### PR TITLE
flake: update for swayfx 0.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,27 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712192574,
-        "narHash": "sha256-LbbVOliJKTF4Zl2b9salumvdMXuQBr2kuKP5+ZwbYq4=",
+        "lastModified": 1713128889,
+        "narHash": "sha256-aB90ZqzosyRDpBh+rILIcyP5lao8SKz8Sr2PSWvZrzk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f480f9d09e4b4cf87ee6151eba068197125714de",
+        "rev": "2748d22b45a99fb2deafa5f11c7531c212b2cefa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1713128889,
+        "narHash": "sha256-aB90ZqzosyRDpBh+rILIcyP5lao8SKz8Sr2PSWvZrzk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2748d22b45a99fb2deafa5f11c7531c212b2cefa",
         "type": "github"
       },
       "original": {
@@ -18,7 +34,26 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "scenefx": "scenefx"
+      }
+    },
+    "scenefx": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1713201995,
+        "narHash": "sha256-QQ2YwWEMQyf9g8HpiQWjS28xR1m/oPHOgJELf24eYVI=",
+        "owner": "ozwaldorf",
+        "repo": "scenefx",
+        "rev": "b75d2570841b21cf1abf8c4780941505432f0562",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ozwaldorf",
+        "repo": "scenefx",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713254108,
-        "narHash": "sha256-0TZIsfDbHG5zibtlw6x0yOp3jkInIGaJ35B7Y4G8Pec=",
+        "lastModified": 1713349283,
+        "narHash": "sha256-2bjFu3+1zPWZPPGqF+7rumTvEwmdBHBhjPva/AMSruQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2fd19c8be2551a61c1ddc3d9f86d748f4db94f00",
+        "rev": "2e359fb3162c85095409071d131e08252d91a14f",
         "type": "github"
       },
       "original": {
@@ -43,15 +43,15 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1713463361,
+        "lastModified": 1713495445,
         "narHash": "sha256-dMvGkhjt72NznwI57HLR+Oc6QMctf16W4zI1XYuwnZI=",
-        "owner": "ozwaldorf",
+        "owner": "wlrfx",
         "repo": "scenefx",
-        "rev": "70256d4657e7e533c28445a449dabd5332ddbe1c",
+        "rev": "5ada125a56012923c47fcf3d049fab32eb7104ff",
         "type": "github"
       },
       "original": {
-        "owner": "ozwaldorf",
+        "owner": "wlrfx",
         "repo": "scenefx",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1713362054,
-        "narHash": "sha256-qJ1ahbYBIU36lmpW0XhMj1SQgJ81yec0swp+W7laIzw=",
+        "lastModified": 1713384203,
+        "narHash": "sha256-wOsYh06oebmqmwzLxurHhOk9cKPAoeJ+HzBhYw0ofhs=",
         "owner": "ozwaldorf",
         "repo": "scenefx",
-        "rev": "8ccf8f7226b1e59c8481e8251b05e6ac1638da6c",
+        "rev": "7571acacfd31e8eaed765d2ca68fea282854b079",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1713201995,
-        "narHash": "sha256-QQ2YwWEMQyf9g8HpiQWjS28xR1m/oPHOgJELf24eYVI=",
+        "lastModified": 1713204871,
+        "narHash": "sha256-6cZnJ9FkrPlVis68fx6rbYu2liEe6RtUdI0uvRjlWYc=",
         "owner": "ozwaldorf",
         "repo": "scenefx",
-        "rev": "b75d2570841b21cf1abf8c4780941505432f0562",
+        "rev": "ae83e053505cdf59477460718da2ea599d656f44",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1713384203,
-        "narHash": "sha256-wOsYh06oebmqmwzLxurHhOk9cKPAoeJ+HzBhYw0ofhs=",
+        "lastModified": 1713463361,
+        "narHash": "sha256-dMvGkhjt72NznwI57HLR+Oc6QMctf16W4zI1XYuwnZI=",
         "owner": "ozwaldorf",
         "repo": "scenefx",
-        "rev": "7571acacfd31e8eaed765d2ca68fea282854b079",
+        "rev": "70256d4657e7e533c28445a449dabd5332ddbe1c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713128889,
-        "narHash": "sha256-aB90ZqzosyRDpBh+rILIcyP5lao8SKz8Sr2PSWvZrzk=",
+        "lastModified": 1713254108,
+        "narHash": "sha256-0TZIsfDbHG5zibtlw6x0yOp3jkInIGaJ35B7Y4G8Pec=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2748d22b45a99fb2deafa5f11c7531c212b2cefa",
+        "rev": "2fd19c8be2551a61c1ddc3d9f86d748f4db94f00",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1713204871,
-        "narHash": "sha256-6cZnJ9FkrPlVis68fx6rbYu2liEe6RtUdI0uvRjlWYc=",
+        "lastModified": 1713362054,
+        "narHash": "sha256-qJ1ahbYBIU36lmpW0XhMj1SQgJ81yec0swp+W7laIzw=",
         "owner": "ozwaldorf",
         "repo": "scenefx",
-        "rev": "ae83e053505cdf59477460718da2ea599d656f44",
+        "rev": "8ccf8f7226b1e59c8481e8251b05e6ac1638da6c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -36,10 +36,11 @@
     {
       overlays = rec {
         default = insert;
-        # Override onto the input nixpkgs
-        override = _: prev: mkPackage prev;
-        # Insert using the locked nixpkgs
+        # Insert using the locked nixpkgs. Can be used with any nixpkgs version.
         insert = _: prev: mkPackage (pkgsFor prev.system);
+        # Override onto the input nixpkgs. Users *MUST* have a scenefx overlay
+        # used before this overlay, otherwise pkgs.scenefx will be unavailable
+        override = _: prev: mkPackage prev;
       };
 
       packages = nixpkgs.lib.genAttrs targetSystems (

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
             pkgs.scenefx
           ];
           nativeBuildInputs = with pkgs; [
+            gdb # for debugging
             wayland-scanner
             hwdata # for wlroots
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,7 @@
             inputsFrom = [
               self.packages.${system}.swayfx-unwrapped
               pkgs.wlroots_0_17
+              pkgs.scenefx
             ];
             nativeBuildInputs = with pkgs; [
               wayland-scanner

--- a/flake.nix
+++ b/flake.nix
@@ -28,10 +28,8 @@
             (old: {
               version = "0.3.2-git";
               src = pkgs.lib.cleanSource ./.;
-              nativeBuildInputs = old.nativeBuildInputs ++ [
-                pkgs.cmake
-                pkgs.scenefx
-              ];
+              nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.cmake ];
+              buildInputs = old.buildInputs ++ [ pkgs.scenefx ];
             });
       };
     in

--- a/flake.nix
+++ b/flake.nix
@@ -57,14 +57,12 @@
             pkgs.wlroots_0_17
             pkgs.scenefx
           ];
-          nativeBuildInputs = with pkgs; [
+          packages = with pkgs; [
             gdb # for debugging
-            wayland-scanner
-            hwdata # for wlroots
           ];
-          # Copy the nix version of wlroots into the project
           shellHook = ''
             (
+              # Copy the nix version of wlroots and scenefx into the project
               mkdir -p "$PWD/subprojects" && cd "$PWD/subprojects"
               cp -R --no-preserve=mode,ownership ${pkgs.wlroots_0_17.src} wlroots
               cp -R --no-preserve=mode,ownership ${pkgs.scenefx.src} scenefx

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Swayfx development environment";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    scenefx.url = "github:ozwaldorf/scenefx";
+    scenefx.url = "github:wlrfx/scenefx";
   };
   outputs =
     {
@@ -16,7 +16,7 @@
         swayfx-unwrapped =
           (pkgs.swayfx-unwrapped.override { wlroots_0_16 = pkgs.wlroots_0_17; }).overrideAttrs
             (old: {
-              version = "0.3.2-git";
+              version = "0.4.0-git";
               src = pkgs.lib.cleanSource ./.;
               nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.cmake ];
               buildInputs = old.buildInputs ++ [ pkgs.scenefx ];


### PR DESCRIPTION
## Summary

- Use new scenefx flake+overlay
- Populate the scenefx subproject location with the source in devshell like we do for wlroots
- Document the override overlay requirement for scenefx
- Build swayfx 0.4!

### Required PRs

- https://github.com/wlrfx/scenefx/pull/37
- #290 

### Notes

Once scenefx has a tagged release, we can target that for the flake input. For now, the repo will need a `nix flake update` to use newer iterations of scenefx. Keep in mind this will need to be maintained as scene releases new versions, of course.

I'm also not entirely sure if the override overlay makes sense, I went with a generic pattern where users are required to overlay their own scenefx into nixpkgs (or in the future, nixpkgs will have scenefx natively and that would be used)

---

> [Passing Garnix CI](https://github.com/ozwaldorf/swayfx/runs/23843530598)