### PR TITLE
update wlroots version in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     let
       mkPackage = pkgs: {
         swayfx-unwrapped =
-          (pkgs.swayfx-unwrapped.override { wlroots_0_16 = pkgs.wlroots_0_17; }).overrideAttrs
+          (pkgs.swayfx-unwrapped.override { wlroots = pkgs.wlroots_0_17; }).overrideAttrs
             (old: {
               version = "0.4.0-git";
               src = pkgs.lib.cleanSource ./.;


### PR DESCRIPTION
# Why have I changed this?
The `flake.nix` was failing to build as of recent due to an update to nixos-unstable, which updated wlroots in a way that causes `wlroots_0_16` to no longer exist? I can't really read much Nix so this might just be completely wrong and this fix was just a shot in the dark.