### PR TITLE
Change border size around workspaces (swaybar)

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -233,6 +233,7 @@ sway_cmd cmd_xwayland;
 sway_cmd bar_cmd_bindcode;
 sway_cmd bar_cmd_binding_mode_indicator;
 sway_cmd bar_cmd_bindsym;
+sway_cmd bar_cmd_border_size;
 sway_cmd bar_cmd_colors;
 sway_cmd bar_cmd_font;
 sway_cmd bar_cmd_gaps;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -359,6 +359,7 @@ struct bar_config {
 	enum pango_markup_config pango_markup;
 	char *font;
 	int height; // -1 not defined
+	int border_size;
 	bool workspace_buttons;
 	bool wrap_scroll;
 	char *separator_symbol;

--- a/include/swaybar/config.h
+++ b/include/swaybar/config.h
@@ -43,6 +43,7 @@ struct swaybar_config {
 	list_t *bindings;
 	struct wl_list outputs; // config_output::link
 	int height;
+	int border_size;
 	int status_padding;
 	int status_edge_padding;
 	struct {

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -12,6 +12,7 @@ static const struct cmd_handler bar_handlers[] = {
 	{ "bindcode", bar_cmd_bindcode },
 	{ "binding_mode_indicator", bar_cmd_binding_mode_indicator },
 	{ "bindsym", bar_cmd_bindsym },
+	{ "border_size", bar_cmd_border_size },
 	{ "colors", bar_cmd_colors },
 	{ "font", bar_cmd_font },
 	{ "gaps", bar_cmd_gaps },

--- a/sway/commands/bar/border_size.c
+++ b/sway/commands/bar/border_size.c
@@ -1,0 +1,20 @@
+#include <stdlib.h>
+#include <string.h>
+#include "sway/commands.h"
+#include "log.h"
+
+struct cmd_results *bar_cmd_border_size(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "border_size", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	int border_size = atoi(argv[0]);
+	if (border_size < 0) {
+		return cmd_results_new(CMD_INVALID,
+				"Invalid border_size value: %s", argv[0]);
+	}
+	config->current_bar->border_size = border_size;
+	sway_log(SWAY_DEBUG, "Setting bar border_size to %d on bar: %s",
+			border_size, config->current_bar->id);
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -95,6 +95,7 @@ struct bar_config *default_bar_config(void) {
 	bar->swaybar_command = NULL;
 	bar->font = NULL;
 	bar->height = 0;
+	bar->border_size = 1;
 	bar->workspace_buttons = true;
 	bar->wrap_scroll = false;
 	bar->separator_symbol = NULL;

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -1297,6 +1297,8 @@ json_object *ipc_json_describe_bar_config(struct bar_config *bar) {
 	}
 	json_object_object_add(json, "bar_height",
 			json_object_new_int(bar->height));
+	json_object_object_add(json, "border_size",
+			json_object_new_int(bar->border_size));
 	json_object_object_add(json, "status_padding",
 			json_object_new_int(bar->status_padding));
 	json_object_object_add(json, "status_edge_padding",

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -153,6 +153,7 @@ sway_sources = files(
 	'commands/bar/colors.c',
 	'commands/bar/font.c',
 	'commands/bar/gaps.c',
+	'commands/bar/border_size.c',
 	'commands/bar/height.c',
 	'commands/bar/hidden_state.c',
 	'commands/bar/icon_theme.c',

--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -52,6 +52,9 @@ runtime.
 *height* <height>
 	Sets the height of the bar. Default height (0) will match the font size.
 
+*border_size* <size>
+	Sets the size of the border around the workspaces. Default is 1
+
 *hidden_state* hide|show [<bar-id>]
 	Specifies the behaviour of the bar when it is in _hide_ mode. When the
 	hidden state is _hide_, then it is normally hidden, and only unhidden by

--- a/swaybar/config.c
+++ b/swaybar/config.c
@@ -43,6 +43,8 @@ struct swaybar_config *init_config(void) {
 
 	/* height */
 	config->height = 0;
+	/* border */
+	config->border_size = 1;
 
 	/* gaps */
 	config->gaps.top = 0;

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -111,6 +111,11 @@ static bool ipc_parse_config(
 		config->height = json_object_get_int(bar_height);
 	}
 
+	json_object *border_size = json_object_object_get(bar_config, "border_size");
+	if (border_size) {
+		config->border_size = json_object_get_int(border_size);
+	}
+
 	json_object *binding_mode_indicator =
 		json_object_object_get(bar_config, "binding_mode_indicator");
 	if (binding_mode_indicator) {

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -22,7 +22,6 @@
 
 static const int WS_HORIZONTAL_PADDING = 5;
 static const double WS_VERTICAL_PADDING = 1.5;
-static const double BORDER_WIDTH = 1;
 
 struct render_context {
 	cairo_t *cairo;
@@ -431,7 +430,7 @@ static uint32_t predict_workspace_button_length(cairo_t *cairo,
 
 	int ws_vertical_padding = WS_VERTICAL_PADDING;
 	int ws_horizontal_padding = WS_HORIZONTAL_PADDING;
-	int border_width = BORDER_WIDTH;
+	int border_width = config->border_size;
 
 	uint32_t ideal_height = ws_vertical_padding * 2 + text_height
 		+ border_width * 2;
@@ -480,7 +479,7 @@ static uint32_t predict_binding_mode_indicator_length(cairo_t *cairo,
 
 	int ws_vertical_padding = WS_VERTICAL_PADDING;
 	int ws_horizontal_padding = WS_HORIZONTAL_PADDING;
-	int border_width = BORDER_WIDTH;
+	int border_width = config->border_size;
 
 	uint32_t ideal_height = text_height + ws_vertical_padding * 2
 		+ border_width * 2;
@@ -557,7 +556,7 @@ static uint32_t render_binding_mode_indicator(struct render_context *ctx,
 
 	int ws_vertical_padding = WS_VERTICAL_PADDING;
 	int ws_horizontal_padding = WS_HORIZONTAL_PADDING;
-	int border_width = BORDER_WIDTH;
+	int border_width = config->border_size;
 
 	uint32_t ideal_height = text_height + ws_vertical_padding * 2
 		+ border_width * 2;
@@ -636,7 +635,7 @@ static uint32_t render_workspace_button(struct render_context *ctx,
 
 	int ws_vertical_padding = WS_VERTICAL_PADDING;
 	int ws_horizontal_padding = WS_HORIZONTAL_PADDING;
-	int border_width = BORDER_WIDTH;
+	int border_width = config->border_size;
 
 	uint32_t ideal_height = ws_vertical_padding * 2 + text_height
 		+ border_width * 2;


### PR DESCRIPTION
Added a command to change the size of the border around workspaces in swaybar

```sway
bar {
   border_size 5; 
}
```