### PR TITLE
Remove wlroots version override in flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715037484,
-        "narHash": "sha256-OUt8xQFmBU96Hmm4T9tOWTu4oCswCzoVl+pxSq/kiFc=",
+        "lastModified": 1722415718,
+        "narHash": "sha256-5US0/pgxbMksF92k1+eOa8arJTJiPvsdZj9Dl+vJkM4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ad7efee13e0d216bf29992311536fce1d3eefbef",
+        "rev": "c3392ad349a5227f4a3464dce87bcc5046692fce",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     let
       mkPackage = pkgs: {
         swayfx-unwrapped =
-          (pkgs.swayfx-unwrapped.override { wlroots = pkgs.wlroots_0_17; }).overrideAttrs
+          pkgs.swayfx-unwrapped.overrideAttrs
             (old: {
               version = "0.4.0-git";
               src = pkgs.lib.cleanSource ./.;


### PR DESCRIPTION
After NixOS/nixpkgs#330630 building the flake is broken. This is because the commit NixOS/nixpkgs@f0461bc93b9ee0ad44ba129e17f8f89bff82ef4e changed the input for `swayfx-unwrapped` from `wlroots` to `wlroots_0_17`. Because of that, the override in this flake is no longer necessary (and it throws an error).

Note: This only happens when overriding the flake input with the latest version of nixpkgs using `swayfx.inputs.nixpkgs.follows = "nixpkgs"`. It can be avoided by removing this line from your config, but that can create duplication of dependencies.