### PR TITLE
feat: add provided sessions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
               src = pkgs.lib.cleanSource ./.;
               nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.cmake ];
               buildInputs = old.buildInputs ++ [ pkgs.scenefx ];
+              providedSessions = [ pkgs.swayfx-unwrapped.meta.mainProgram ];
             });
       };
 


### PR DESCRIPTION
The NixOS option [`programs.sway.package`](https://search.nixos.org/options?channel=unstable&show=programs.sway.package) works with the `swayfx` version in nixpkgs. However, when using this flake like so:

```nix
programs.sway.package = inputs.swayfx.packages.${pkgs.system}.default;
```

You get the following error:

```
error: Package, 'swayfx-unwrapped-0.4.0-git', did not specify any session names, as strings, in
       'passthru.providedSessions'. This is required when used as a session package.
```

This way it detects the `providedSessions` like in the nixpkgs version and it builds correctly.