### PR TITLE
fix top border size and placement

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1161,9 +1161,11 @@ static void render_top_border(struct fx_render_context *ctx, struct sway_contain
 	// Child border - top edge
 	memcpy(&color, colors->child_border, sizeof(float) * 4);
 	premultiply_alpha(color, con->alpha);
-	box.x = floor(state->x) + corner_radius + state->border_thickness;
+	box.x = floor(state->x) + 
+		(corner_radius != 0) * (corner_radius + state->border_thickness);
 	box.y = floor(state->y);
-	box.width = state->width - (2 * (corner_radius + state->border_thickness));
+	box.width = state->width - 
+		((corner_radius != 0) * 2 * (corner_radius + state->border_thickness));
 	box.height = state->border_thickness;
 	scale_box(&box, output_scale);
 	render_rect(ctx, &box, color);

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1161,9 +1161,9 @@ static void render_top_border(struct fx_render_context *ctx, struct sway_contain
 	// Child border - top edge
 	memcpy(&color, colors->child_border, sizeof(float) * 4);
 	premultiply_alpha(color, con->alpha);
-	box.x = floor(state->x) + corner_radius;
+	box.x = floor(state->x) + state->border_thickness;
 	box.y = floor(state->y);
-	box.width = state->width - (2 * corner_radius);
+	box.width = state->width - (2 * state->border_thickness);
 	box.height = state->border_thickness;
 	scale_box(&box, output_scale);
 	render_rect(ctx, &box, color);

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1161,9 +1161,9 @@ static void render_top_border(struct fx_render_context *ctx, struct sway_contain
 	// Child border - top edge
 	memcpy(&color, colors->child_border, sizeof(float) * 4);
 	premultiply_alpha(color, con->alpha);
-	box.x = floor(state->x) + state->border_thickness;
+	box.x = floor(state->x) + corner_radius + state->border_thickness;
 	box.y = floor(state->y);
-	box.width = state->width - (2 * state->border_thickness);
+	box.width = state->width - (2 * (corner_radius + state->border_thickness));
 	box.height = state->border_thickness;
 	scale_box(&box, output_scale);
 	render_rect(ctx, &box, color);


### PR DESCRIPTION
top border is sized and place incorrectly when using the pixel styled border

![image](https://github.com/user-attachments/assets/b4758de8-edfb-4b78-9ca5-67599e3603af)
