### PR TITLE
Only apply corner_radius to container if there is one

### DIFF
--- a/sway/commands/corner_radius.c
+++ b/sway/commands/corner_radius.c
@@ -25,8 +25,13 @@ struct cmd_results *cmd_corner_radius(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "Invalid size specified");
 	}
 
-	config->corner_radius = value;
+	struct sway_container *con = config->handler_context.container;
 
+	if (con == NULL) {
+		config->corner_radius = value;
+	} else {
+		con->corner_radius = value;
+	}
 	/*
 	 titlebar padding depends on corner_radius to
 	 ensure that titlebars are rendered nicely


### PR DESCRIPTION
I noticed that when I use a `for_window` command in my sway config where I set the `corner_radius`, this applies to every window as soon as a window matching the `for_window`-criteria was opened.

This seems to happen due to a missing check at https://github.com/WillPower3309/swayfx/blob/3e4b6b75f4b42b4cb04d883033b04b4a1b57bc90/sway/commands/corner_radius.c#L28
which means that a `corner_radius` will always be set in the "global" configuration.

This PR adapts the check from https://github.com/WillPower3309/swayfx/blob/3e4b6b75f4b42b4cb04d883033b04b4a1b57bc90/sway/commands/blur.c#L17-L21