### PR TITLE
fix(flake): swayfx builds again

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,27 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727089097,
-        "narHash": "sha256-ZMHMThPsthhUREwDebXw7GX45bJnBCVbfnH1g5iuSPc=",
+        "lastModified": 1739698114,
+        "narHash": "sha256-8S9n69Dnpg8DhfFlP0YvMGmSOY2X4kImGSPWXYNpaHM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "568bfef547c14ca438c56a0bece08b8bb2b71a9c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1713128889,
-        "narHash": "sha256-aB90ZqzosyRDpBh+rILIcyP5lao8SKz8Sr2PSWvZrzk=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "2748d22b45a99fb2deafa5f11c7531c212b2cefa",
+        "rev": "b1b43d32be000928cc71250ed77f4a0a5f2bc23a",
         "type": "github"
       },
       "original": {
@@ -40,14 +24,16 @@
     },
     "scenefx": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1726812372,
-        "narHash": "sha256-JyEaeuwgPr041MaNz7EgvxPmYcx/Z46xEvalw5eu8Q4=",
+        "lastModified": 1739733667,
+        "narHash": "sha256-BLIADMQwPJUtl6hFBhh5/xyYwLFDnNQz0RtgWO/Ua8s=",
         "owner": "wlrfx",
         "repo": "scenefx",
-        "rev": "be3eea191cb9aecea1ddf4f1399bcbb390027998",
+        "rev": "87c0e8b6d5c86557a800445e8e4c322f387fe19c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,10 @@
   description = "Swayfx development environment";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    scenefx.url = "github:wlrfx/scenefx";
-scenefx = {
-    url = "github:wlrfx/scenefx";
-    inputs.nixpkgs.follows = "nixpkgs";
-};
+    scenefx = {
+      url = "github:wlrfx/scenefx";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
   outputs =
     {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,10 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     scenefx.url = "github:wlrfx/scenefx";
-    scenefx.inputs.nixpkgs.follows = "nixpkgs";
+scenefx = {
+    url = "github:wlrfx/scenefx";
+    inputs.nixpkgs.follows = "nixpkgs";
+};
   };
   outputs =
     {

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     scenefx.url = "github:wlrfx/scenefx";
+    scenefx.inputs.nixpkgs.follows = "nixpkgs";
   };
   outputs =
     {
@@ -14,13 +15,23 @@
     let
       mkPackage = pkgs: {
         swayfx-unwrapped =
-          pkgs.swayfx-unwrapped.overrideAttrs
+          (pkgs.swayfx-unwrapped.override {
+            wlroots_0_17 = pkgs.wlroots_0_18;
+          }).overrideAttrs
             (old: {
               version = "0.4.0-git";
               src = pkgs.lib.cleanSource ./.;
               nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.cmake ];
               buildInputs = old.buildInputs ++ [ pkgs.scenefx ];
               providedSessions = [ pkgs.swayfx-unwrapped.meta.mainProgram ];
+              patches = []; ## this should probably be fixed properly
+              mesonFlags = let
+                inherit (pkgs.lib.strings) mesonEnable mesonOption;
+              in
+                [
+                  (mesonOption "sd-bus-provider" "libsystemd")
+                  (mesonEnable "tray" true)
+                ];
             });
       };
 
@@ -55,7 +66,7 @@
           name = "swayfx-shell";
           inputsFrom = [
             self.packages.${pkgs.system}.swayfx-unwrapped
-            pkgs.wlroots_0_17
+            pkgs.wlroots_0_18
             pkgs.scenefx
           ];
           packages = with pkgs; [
@@ -65,7 +76,7 @@
             (
               # Copy the nix version of wlroots and scenefx into the project
               mkdir -p "$PWD/subprojects" && cd "$PWD/subprojects"
-              cp -R --no-preserve=mode,ownership ${pkgs.wlroots_0_17.src} wlroots
+              cp -R --no-preserve=mode,ownership ${pkgs.wlroots_0_18.src} wlroots
               cp -R --no-preserve=mode,ownership ${pkgs.scenefx.src} scenefx
             )'';
         };


### PR DESCRIPTION
This fixes #381 . I'm not sure we want to skip the patches but haven't bothered looking into what needs to happen there. We can't keep the ones from the nixpkgs package at least for now.