### PR TITLE
fix: correct scenefx pkg-config dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -44,7 +44,7 @@ subproject(
 	'scenefx',
 	required: false,
 )
-scenefx = dependency('scenefx-0.2', fallback: 'scenefx')
+scenefx = dependency('scenefx', version: '0.2', fallback: 'scenefx')
 
 # Execute the wlroots subproject, if any
 wlroots_version = ['>=0.18.0', '<0.19.0']


### PR DESCRIPTION
meson.build has a dependency on scenefx-0.2.
This causes pkg-config to check for scenefx-0.2.pc, which doesn't exist, because scenefx doesn't use versioned pkg-config files.
Instead scenefx ships scenefx.pc which includes a version.
The fallback tries to build the submodule, not use scenefx.pc.

This patch fixes the dependency and the version check.