### PR TITLE
Remove wlroot version override in nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,6 @@
       mkPackage = pkgs: {
         swayfx-unwrapped =
           (pkgs.swayfx-unwrapped.override {
-            wlroots_0_17 = pkgs.wlroots_0_18;
           }).overrideAttrs
             (old: {
               version = "0.4.0-git";


### PR DESCRIPTION
The nix flake fails to build due to it overriding a wlroots version that is no longer in the base package, this PR removes the override.