### PR TITLE
add docker builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,81 @@
+# syntax = docker/dockerfile:1.3-labs
+FROM debian:trixie as builder
+
+ARG WLROOTSVERSION=0.19.0
+ARG WLROOTSLIBVERSION=0.19
+ARG SWAYFXVERSION=0.5.2
+ARG SCENEFXVERSION=0.4.1
+ARG SCENEFXLIBVERSION=0.4
+
+ENV LANG C.UTF-8
+
+RUN apt update && apt install -y --no-install-recommends \
+               build-essential \
+               cmake \
+               cdbs \
+               devscripts \
+               equivs \
+               meson \
+               wayland-protocols \
+               libwayland-dev \
+               libwayland-bin \
+               libwayland-client0 \
+               libdrm-dev \
+               libxkbcommon-dev \
+               libudev-dev \
+               hwdata \
+               libseat-dev \
+               libgles-dev \
+               libavutil-dev \
+               libavcodec-dev \
+               libavformat-dev \
+               libgbm-dev \
+               xwayland \
+               libxcb-composite0-dev \
+               libxcb-icccm4-dev \
+               libxcb-res0-dev \
+               libxcb-errors-dev \
+               libinput-dev \
+               libxcb-present-dev \
+               libxcb-render-util0-dev \
+               libxcb-xinput-dev \
+               glslang-tools \
+               glslang-dev \
+               libpcre2-dev \
+               libjson-c-dev \
+               libgdk-pixbuf-2.0-dev \
+               libsystemd-dev \
+               scdoc \
+               bash-completion \
+               libpango1.0-dev \
+               libcairo2-dev \
+               libxcb-ewmh-dev \
+               libdisplay-info-dev \
+               libliftoff-dev \
+               liblcms2-dev \
+               libvulkan-dev \
+               wget \
+               bash \
+               git \
+               ca-certificates \
+               && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+RUN wget https://gitlab.freedesktop.org/wlroots/wlroots/-/archive/$WLROOTSVERSION/wlroots-$WLROOTSVERSION.tar.gz
+RUN tar -xf wlroots-$WLROOTSVERSION.tar.gz
+RUN rm wlroots-$WLROOTSVERSION.tar.gz
+
+RUN wget https://github.com/WillPower3309/swayfx/archive/refs/tags/$SWAYFXVERSION.tar.gz
+RUN tar -xf $SWAYFXVERSION.tar.gz
+RUN rm $SWAYFXVERSION.tar.gz
+
+RUN wget https://github.com/wlrfx/scenefx/archive/refs/tags/$SCENEFXVERSION.tar.gz
+RUN tar -xf $SCENEFXVERSION.tar.gz
+RUN rm $SCENEFXVERSION.tar.gz
+
+COPY build.sh .
+RUN chmod 755 build.sh
+
+ENTRYPOINT ["/build/build.sh"]
+

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -e pipefail
+
+meson setup --prefix /opt wlroots-$WLROOTSVERSION/build/ wlroots-$WLROOTSVERSION 
+ninja -C wlroots-$WLROOTSVERSION/build/ 
+ninja -C wlroots-$WLROOTSVERSION/build/ install 
+ls -l /opt/lib/x86_64-linux-gnu/pkgconfig 
+echo wlroots DONE 
+
+PKG_CONFIG_PATH=/opt/lib/x86_64-linux-gnu/pkgconfig/:$PKG_CONFIG_PATH \
+meson setup --prefix /opt --cmake-prefix-path /opt scenefx-$SCENEFXVERSION/build/ scenefx-$SCENEFXVERSION 
+ninja -C scenefx-$SCENEFXVERSION/build/ 
+ninja -C scenefx-$SCENEFXVERSION/build/ install 
+echo scenefx DONE
+
+PKG_CONFIG_PATH=/opt/lib/x86_64-linux-gnu/pkgconfig/:$PKG_CONFIG_PATH \
+meson setup --prefix /opt --cmake-prefix-path /opt swayfx-$SWAYFXVERSION/build/ swayfx-$SWAYFXVERSION 
+ninja -C swayfx-$SWAYFXVERSION/build/ 
+ninja -C swayfx-$SWAYFXVERSION/build/ install 
+echo swayfx DONE
+
+mv /opt/bin/sway /opt/bin/swayfx
+
+cat <<EOF > /opt/bin/swayfx.sh
+#!/bin/sh
+export PATH=/opt/bin:\$PATH
+export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/opt/lib/x86_64-linux-gnu/
+exec /opt/bin/swayfx
+EOF
+
+chmod 755  /opt/bin/swayfx.sh
+
+echo
+echo "Successfully build swayfx. Find it in your hosts bind directory (default: ./opt)."

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: "3.9"
+services:
+  swayfxbuild:
+    container_name: swayfxbuild
+    working_dir: /build
+    build: .
+    image: swayfxbuild:latest
+    environment:
+      - WLROOTSVERSION=0.19.0
+      - WLROOTSLIBVERSION=0.19
+      - SWAYFXVERSION=0.5.2
+      - SCENEFXVERSION=0.4.1
+      - SCENEFXLIBVERSION=0.4
+    volumes:
+      - ./opt:/opt
+


### PR DESCRIPTION
You can use this docker file to build swayfx. It could be enhanced to build a debian package as well. Currently it just builds everything and copies it to `/opt`. To use:

```default
mkdir opt
docker-compose build
docker-compose run swayfxbuild
```

Then copy `./opt` to `/opt` and create a deskteop file, e.g.:

```default
[Desktop Entry]
Name=SwayFX
Comment=An i3-compatible Wayland compositor
Exec=/opt/bin/swayfx.sh
Type=Application
DesktopNames=swayfx
```

