### PR TITLE
blur: fix random pop up

### DIFF
--- a/sway/commands/blur.c
+++ b/sway/commands/blur.c
@@ -27,7 +27,7 @@ struct cmd_results *cmd_blur(int argc, char **argv) {
 		arrange_root();
 	} else {
 		con->blur_enabled = result;
-		container_update(con);
+		arrange_container(con);
 	}
 
 	struct sway_output *output;

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -306,8 +306,6 @@ void container_update(struct sway_container *con) {
 		sway_text_node_set_background(con->title_bar.marks_text, colors->background);
 	}
 
-	wlr_scene_node_set_enabled(&con->blur->node, con->blur_enabled);
-
 	if (con->dim_rect) {
 		float *color = config->dim_inactive_colors.unfocused;
 


### PR DESCRIPTION
blur was being enabled inside of `container_update` which is unaware of it's position inside of the tree