### PR TITLE
add window decoration buttons

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -224,6 +224,8 @@ sway_cmd cmd_unbindgesture;
 sway_cmd cmd_unbindsym;
 sway_cmd cmd_unmark;
 sway_cmd cmd_urgent;
+sway_cmd cmd_window_button;
+sway_cmd cmd_window_button_style;
 sway_cmd cmd_workspace;
 sway_cmd cmd_workspace_layout;
 sway_cmd cmd_ws_auto_back_and_forth;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -473,11 +473,27 @@ enum alignment {
 	ALIGN_RIGHT,
 };
 
+enum vertical_alignment {
+	V_ALIGN_TOP,
+	V_ALIGN_MIDDLE,
+	V_ALIGN_BOTTOM,
+};
+
 enum xwayland_mode {
 	XWAYLAND_MODE_DISABLED,
 	XWAYLAND_MODE_LAZY,
 	XWAYLAND_MODE_IMMEDIATE,
 };
+
+struct window_button {
+	char *id;
+	char* command;
+	float color[4];
+};
+
+struct window_button *window_button_copy(struct window_button *orig);
+
+void window_button_free(struct window_button *button);
 
 /**
  * The configuration struct. The result of loading a config file.
@@ -522,6 +538,12 @@ struct sway_config {
 	list_t *criteria;
 	list_t *no_focus;
 	list_t *active_bar_modifiers;
+	list_t *window_buttons;
+	int window_button_size;
+	int window_button_gaps;
+	int window_button_radius;
+	int window_button_margin;
+	enum vertical_alignment window_button_vertical_align;
 	struct sway_mode *current_mode;
 	struct bar_config *current_bar;
 	uint32_t floating_mod;

--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -86,7 +86,7 @@ struct sway_node;
 
 struct sway_node *node_at_coords(
 		struct sway_seat *seat, double lx, double ly,
-		struct wlr_surface **surface, double *sx, double *sy);
+		struct wlr_surface **surface, struct sway_container_button **button, double *sx, double *sy);
 
 void sway_cursor_destroy(struct sway_cursor *cursor);
 struct sway_cursor *sway_cursor_create(struct sway_seat *seat);

--- a/include/sway/scene_descriptor.h
+++ b/include/sway/scene_descriptor.h
@@ -19,6 +19,7 @@ enum sway_scene_descriptor_type {
 	SWAY_SCENE_DESC_XWAYLAND_UNMANAGED,
 	SWAY_SCENE_DESC_POPUP,
 	SWAY_SCENE_DESC_DRAG_ICON,
+	SWAY_SCENE_DESC_BUTTON,
 };
 
 bool scene_descriptor_assign(struct wlr_scene_node *node,

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -65,6 +65,11 @@ struct sway_container_state {
 	double content_width, content_height;
 };
 
+struct sway_container_button {
+	struct wlr_scene_rect *background;
+	int button_idx;
+};
+
 struct sway_container {
 	struct sway_node node;
 	struct sway_view *view;
@@ -79,6 +84,7 @@ struct sway_container {
 
 		struct sway_text_node *title_text;
 		struct sway_text_node *marks_text;
+		list_t *buttons;
 	} title_bar;
 
 	struct {
@@ -154,6 +160,7 @@ struct sway_container {
 	float dim;
 
 	list_t *marks; // char *
+	list_t *buttons;
 
 	struct {
 		struct wl_signal destroy;
@@ -194,6 +201,8 @@ struct sway_container *container_flatten(struct sway_container *container);
 void container_update_title_bar(struct sway_container *container);
 
 void container_update_marks(struct sway_container *container);
+
+void container_update_buttons(struct sway_container *con);
 
 size_t parse_title_format(struct sway_container *container, char *buffer);
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -117,6 +117,8 @@ static const struct cmd_handler handlers[] = {
 	{ "unbindgesture", cmd_unbindgesture },
 	{ "unbindswitch", cmd_unbindswitch },
 	{ "unbindsym", cmd_unbindsym },
+	{ "window_button", cmd_window_button },
+	{ "window_button_style", cmd_window_button_style },
 	{ "workspace", cmd_workspace },
 	{ "workspace_auto_back_and_forth", cmd_ws_auto_back_and_forth },
 };

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -622,7 +622,7 @@ void seat_execute_command(struct sway_seat *seat, struct sway_binding *binding) 
 		double sx, sy;
 		struct sway_node *node = node_at_coords(seat,
 				seat->cursor->cursor->x, seat->cursor->cursor->y,
-				&surface, &sx, &sy);
+				&surface, NULL, &sx, &sy);
 		if (node && node->type == N_CONTAINER) {
 			con = node->sway_container;
 		}

--- a/sway/commands/window_button.c
+++ b/sway/commands/window_button.c
@@ -1,0 +1,134 @@
+#include "log.h"
+#include "util.h"
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/output.h"
+#include "sway/tree/arrange.h"
+
+static struct window_button *find_button(list_t *buttons, char *id, int *index);
+
+struct cmd_results* cmd_window_button(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "window_button", EXPECTED_AT_LEAST, 2))) {
+		return error;
+	}
+
+	int button_index = 0;
+	bool visual_changes = false;
+
+	list_t *target = config->window_buttons;
+
+	int arg = 0;
+	if (strcmp("default", argv[arg]) == 0) {
+		arg++;
+	} else {
+		struct sway_container *container = config->handler_context.container;
+		if (!container || !container->view) {
+			return cmd_results_new(CMD_INVALID, "Only views can have borders");
+		}
+
+		target = container->buttons;
+	}
+
+	struct window_button *selected = find_button(target, argv[arg+1], &button_index);
+	if (strcmp("remove", argv[arg]) == 0) {
+		if (selected == NULL) {
+			return cmd_results_new(CMD_SUCCESS, NULL);
+		}
+
+		list_del(target, button_index);
+		free(selected->id);
+		free(selected->command);
+		free(selected);
+		visual_changes = true;
+		goto cleanup;
+	}
+
+	if (strcmp("set", argv[arg]) != 0) {
+		return cmd_results_new(CMD_INVALID, "Invalid window_button command: expecting remove or set");
+	}
+
+	arg += 1;
+
+	if (selected == NULL) {
+		selected = calloc(1, sizeof(*selected));
+		if (!selected) {
+			return cmd_results_new(CMD_FAILURE, "window_button command failed: out of memory");
+		}
+		selected->id = malloc(strlen(argv[arg])+1);
+		if (!selected->id) {
+			return cmd_results_new(CMD_FAILURE, "window_button command failed: out of memory");
+		}
+		strcpy(selected->id, argv[arg]);
+		selected->command = NULL;
+		list_add(target, selected);
+		visual_changes = true;
+	}
+
+	arg+=1;
+
+	while ((arg + 1) < argc) {
+		bool is_after = false;
+		char *action = argv[arg];
+		char *value = argv[arg+1];
+		if (strcmp("cmd", action) == 0 || strcmp("command", action) == 0) {
+			if (selected->command != NULL && strcmp(selected->command, value) == 0) {
+				goto next;
+			}
+
+			if (selected->command != NULL) {
+				free(selected->command);
+			}
+
+			selected->command = malloc(strlen(value)+1);
+			strcpy(selected->command, value);
+		} else if (strcmp("color", action) == 0) {
+			uint32_t rgb;
+			if (parse_color(value, &rgb)) {
+				color_to_rgba(selected->color, rgb);
+			}
+			visual_changes = true;
+		} else if (strcmp("before", action) == 0 || ((is_after = (strcmp("after", action) == 0)))) {
+			int other;
+			find_button(target, value, &other);
+			if (other == -1 || other == button_index) {
+				goto next;
+			}
+
+			list_del(target, button_index);
+
+			if (button_index < other) {
+				other -= 1;
+			}
+
+			if (is_after) {
+				other += 1;
+			}
+
+			list_insert(target, other, selected);
+			visual_changes = true;
+		}
+
+next:
+		arg += 2;
+	}
+cleanup:
+	if (visual_changes && config->handler_context.container) {
+		container_update_buttons(config->handler_context.container);
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}
+
+static struct window_button *find_button(list_t *buttons, char *id, int *index) {
+	for (int i = 0; i < buttons->length; i++) {
+		struct window_button *item = buttons->items[i];
+		if (strcmp(id, item->id) == 0) {
+			*index = i;
+			return item;
+		}
+	}
+
+	*index = -1;
+	return NULL;
+}

--- a/sway/commands/window_button_style.c
+++ b/sway/commands/window_button_style.c
@@ -1,0 +1,79 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "sway/commands.h"
+#include "sway/output.h"
+#include "sway/tree/arrange.h"
+
+struct cmd_results* read_int(char *input, int *output, const char * name);
+
+struct cmd_results* cmd_window_button_style(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "window_button_style", EXPECTED_AT_LEAST, 2))) {
+		return error;
+	}
+
+	int arg = 0;
+	while ((arg+1) < argc) {
+		char *name = argv[arg];
+		char *value = argv[arg+1];
+
+		if (strcmp(name, "gaps") == 0) {
+			if ((error = read_int(value, &config->window_button_gaps, "gaps"))) {
+				return error;
+			}
+		}
+
+		if (strcmp(name, "align") == 0) {
+			if (strcmp(value, "top") == 0) {
+				config->window_button_vertical_align = V_ALIGN_TOP;
+			}
+
+			if (strcmp(value, "middle") == 0) {
+				config->window_button_vertical_align = V_ALIGN_MIDDLE;
+			}
+
+			if (strcmp(value, "bottom") == 0) {
+				config->window_button_vertical_align = V_ALIGN_BOTTOM;
+			}
+		}
+
+		if (strcmp(name, "margin") == 0) {
+			if ((error = read_int(value, &config->window_button_margin, "margin"))) {
+				return error;
+			}
+		}
+
+		if (strcmp(name, "size") == 0) {
+			if ((error = read_int(value, &config->window_button_size, "size"))) {
+				return error;
+			}
+		}
+
+		if (strcmp(name, "radius") == 0) {
+			if ((error = read_int(value, &config->window_button_radius, "radius"))) {
+				return error;
+			}
+		}
+
+		arg += 2;
+	}
+
+	for (int i = 0; i < root->outputs->length; ++i) {
+		struct sway_output *output = root->outputs->items[i];
+		arrange_workspace(output_get_active_workspace(output));
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}
+
+struct cmd_results* read_int(char *input, int *output, const char *name) {
+	char *inv;
+	int v = strtol(input, &inv, 10);
+	if (*inv != '\0' || v < 0) {
+		return cmd_results_new(CMD_FAILURE, "invalid window_button_style %s given, invalid int", name);
+	}
+
+	*output = v;
+	return NULL;
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -173,6 +173,12 @@ void free_config(struct sway_config *config) {
 		}
 		list_free(config->layer_criteria);
 	}
+	if (config->window_buttons) {
+		for (int i = 0; i < config->window_buttons->length; ++i) {
+			window_button_free(config->window_buttons->items[i]);
+		}
+		list_free(config->window_buttons);
+	}
 	list_free(config->no_focus);
 	list_free(config->active_bar_modifiers);
 	list_free_items_and_destroy(config->config_chain);
@@ -297,6 +303,13 @@ static void config_defaults(struct sway_config *config) {
 	config->gaps_outer.right = 0;
 	config->gaps_outer.bottom = 0;
 	config->gaps_outer.left = 0;
+
+	if (!(config->window_buttons = create_list())) goto cleanup;
+	config->window_button_gaps = 10;
+	config->window_button_radius = 0;
+	config->window_button_size = 20;
+	config->window_button_margin = 20;
+	config->window_button_vertical_align = V_ALIGN_TOP;
 
 	if (!(config->active_bar_modifiers = create_list())) goto cleanup;
 
@@ -1044,4 +1057,32 @@ void translate_keysyms(struct input_config *input_config) {
 
 	sway_log(SWAY_DEBUG, "Translated keysyms using config for device '%s'",
 			input_config->identifier);
+}
+
+struct window_button *window_button_copy(struct window_button *orig) {
+	struct window_button *copy = malloc(sizeof(*orig));
+	if (orig->id != NULL) {
+		copy->id = malloc(strlen(orig->id) + 1);
+		strcpy(copy->id, orig->id);
+	}
+
+	if (orig->command != NULL) {
+		copy->command = malloc(strlen(orig->command) + 1);
+		strcpy(copy->command, orig->command);
+	}
+
+	memcpy(copy->color, orig->color, 4 * sizeof(float));
+	return copy;
+}
+
+void window_button_free(struct window_button *button) {
+	if (button->id != NULL) {
+		free(button->id);
+	}
+
+	if (button->command != NULL) {
+		free(button->command);
+	}
+
+	free(button);
 }

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -44,7 +44,7 @@ static uint32_t get_current_time_msec(void) {
  */
 struct sway_node *node_at_coords(
 		struct sway_seat *seat, double lx, double ly,
-		struct wlr_surface **surface, double *sx, double *sy) {
+		struct wlr_surface **surface, struct sway_container_button** button, double *sx, double *sy) {
 	struct wlr_scene_node *scene_node = NULL;
 
 	struct wlr_scene_node *node;
@@ -74,6 +74,10 @@ struct sway_node *node_at_coords(
 			if (scene_surface) {
 				*surface = scene_surface->surface;
 			}
+		}
+
+		if (scene_node->type == WLR_SCENE_NODE_RECT && button != NULL) {
+			 *button = scene_descriptor_try_get(scene_node, SWAY_SCENE_DESC_BUTTON);
 		}
 
 		// determine what container we clicked on
@@ -306,7 +310,7 @@ void pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 		struct wlr_surface *surface = NULL;
 		double sx, sy;
 		node_at_coords(cursor->seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+			cursor->cursor->x, cursor->cursor->y, &surface, NULL, &sx, &sy);
 
 		if (cursor->active_constraint->surface != surface) {
 			return;
@@ -565,7 +569,7 @@ static void handle_tablet_tool_position(struct sway_cursor *cursor,
 	double sx, sy;
 	struct wlr_surface *surface = NULL;
 	struct sway_seat *seat = cursor->seat;
-	node_at_coords(seat, cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	node_at_coords(seat, cursor->cursor->x, cursor->cursor->y, &surface, NULL, &sx, &sy);
 
 	// The logic for whether we should send a tablet event or an emulated pointer
 	// event is tricky. It comes down to:
@@ -656,7 +660,7 @@ static void handle_tool_tip(struct wl_listener *listener, void *data) {
 	double sx, sy;
 	struct wlr_surface *surface = NULL;
 	node_at_coords(seat, cursor->cursor->x, cursor->cursor->y,
-		&surface, &sx, &sy);
+		&surface, NULL, &sx, &sy);
 
 	if (cursor->simulating_pointer_from_tool_tip &&
 			event->state == WLR_TABLET_TOOL_TIP_UP) {
@@ -741,7 +745,7 @@ static void handle_tool_button(struct wl_listener *listener, void *data) {
 	struct wlr_surface *surface = NULL;
 
 	node_at_coords(cursor->seat, cursor->cursor->x, cursor->cursor->y,
-		&surface, &sx, &sy);
+		&surface, NULL, &sx, &sy);
 
 	// TODO: floating resize should support graphics tablet events
 	struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(cursor->seat->wlr_seat);

--- a/sway/input/seatop_down.c
+++ b/sway/input/seatop_down.c
@@ -76,7 +76,7 @@ static void handle_touch_down(struct sway_seat *seat,
 	double sx, sy;
 	struct wlr_surface *surface = NULL;
 	struct sway_node *focused_node = node_at_coords(seat, seat->touch_x,
-		seat->touch_y, &surface, &sx, &sy);
+		seat->touch_y, &surface, NULL, &sx, &sy);
 
 	if (!surface || surface != e->surface) { // Must start from the initial surface
 		return;

--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -185,7 +185,7 @@ static void handle_motion_postthreshold(struct sway_seat *seat) {
 	double sx, sy;
 	struct sway_cursor *cursor = seat->cursor;
 	struct sway_node *node = node_at_coords(seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+			cursor->cursor->x, cursor->cursor->y, &surface, NULL, &sx, &sy);
 
 	if (!node) {
 		// Eg. hovered over a layer surface such as swaybar

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -143,6 +143,8 @@ sway_sources = files(
 	'commands/titlebar_separator.c',
 	'commands/unmark.c',
 	'commands/urgent.c',
+    'commands/window_button.c',
+    'commands/window_button_style.c',
 	'commands/workspace.c',
 	'commands/workspace_layout.c',
 	'commands/ws_auto_back_and_forth.c',


### PR DESCRIPTION
Small draft PR with fully functional window deco buttons, with styling and commands


New commands added:
```
window_button [default] (remove <id> | set <id> [cmd <cmd>] [color <color>] [(after|before) <other>])
window_button_style [gaps <px>] [margin <px>] [radius <px>] [align (bottom|middle|top)] [size <px>]
```

Unsure how serious this MR is. I mostly did it as a joke, and then locked in

### Preview


https://github.com/user-attachments/assets/9bf29f87-fdc6-484c-88c4-f232165bd99f

