### PR TITLE
mark optimized blur dirty on any output changes

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -952,6 +952,11 @@ static bool apply_resolved_output_configs(struct matched_output_config *configs,
 	// around, so we do a second pass to update positions and arrange.
 	for (size_t idx = 0; idx < configs_len; idx++) {
 		struct matched_output_config *cfg = &configs[idx];
+		// since everything got moved around, mark the optimized blur as dirty
+		// this is to catch e.g. the output transform since it directly picks things up from the fbo
+		if (cfg->output->layers.blur_layer) {
+			cfg->output->layers.blur_layer->dirty = true;
+		}
 		output_update_position(cfg->output);
 		arrange_layers(cfg->output);
 	}


### PR DESCRIPTION
Fixes an issue when e.g. going from `transform 0` to `transform 180` and the optimized blur doesn't get marked dirty because there's not any reconfigure actually needed

Example

<img width="1912" height="1017" alt="20251120_16h15m41s_grim" src="https://github.com/user-attachments/assets/a5c7c2a3-d60f-421c-9a18-8d3c9614e77c" />
