### PR TITLE
Remove heredoc bash syntax and use sh syntax for podman compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,59 +8,56 @@ SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 ENV LANG=C.UTF-8
 
 RUN <<EOF
-  PACKAGES=(
-    build-essential
-    cmake
-    cdbs
-    devscripts
-    equivs
-    meson
-    wayland-protocols
-    libwayland-dev
-    libwayland-bin
-    libwayland-client0
-    libdrm-dev
-    libxkbcommon-dev
-    libudev-dev
-    hwdata
-    libseat-dev
-    libgles-dev
-    libavutil-dev
-    libavcodec-dev
-    libavformat-dev
-    libgbm-dev
-    xwayland
-    libxcb-composite0-dev
-    libxcb-icccm4-dev
-    libxcb-res0-dev
-    libxcb-errors-dev
-    libinput-dev
-    libxcb-present-dev
-    libxcb-render-util0-dev
-    libxcb-xinput-dev
-    glslang-tools
-    glslang-dev
-    libpcre2-dev
-    libjson-c-dev
-    libgdk-pixbuf-2.0-dev
-    libsystemd-dev
-    scdoc
-    bash-completion
-    libpango1.0-dev
-    libcairo2-dev
-    libxcb-ewmh-dev
-    libdisplay-info-dev
-    libliftoff-dev
-    liblcms2-dev
-    libvulkan-dev
-    wget
-    bash
-    git
-    ca-certificates
-  )
-
   apt-get update
-  apt-get --yes install --no-install-recommends "${PACKAGES[@]}"
+  apt-get --yes install --no-install-recommends \
+    build-essential \
+    cmake \
+    cdbs \
+    devscripts \
+    equivs \
+    meson \
+    wayland-protocols \
+    libwayland-dev \
+    libwayland-bin \
+    libwayland-client0 \
+    libdrm-dev \
+    libxkbcommon-dev \
+    libudev-dev \
+    hwdata \
+    libseat-dev \
+    libgles-dev \
+    libavutil-dev \
+    libavcodec-dev \
+    libavformat-dev \
+    libgbm-dev \
+    xwayland \
+    libxcb-composite0-dev \
+    libxcb-icccm4-dev \
+    libxcb-res0-dev \
+    libxcb-errors-dev \
+    libinput-dev \
+    libxcb-present-dev \
+    libxcb-render-util0-dev \
+    libxcb-xinput-dev \
+    glslang-tools \
+    glslang-dev \
+    libpcre2-dev \
+    libjson-c-dev \
+    libgdk-pixbuf-2.0-dev \
+    libsystemd-dev \
+    scdoc \
+    bash-completion \
+    libpango1.0-dev \
+    libcairo2-dev \
+    libxcb-ewmh-dev \
+    libdisplay-info-dev \
+    libliftoff-dev \
+    liblcms2-dev \
+    libvulkan-dev \
+    wget \
+    bash \
+    git \
+    ca-certificates
 EOF
 
 WORKDIR /build


### PR DESCRIPTION
When compiling the project via `podman compose up --build` instead of using docker, the build fails:
```
STEP 4/17: RUN <<EOF (PACKAGES=(...)
/bin/sh: 2: Syntax error: "(" unexpected
Error: building at STEP "RUN <<EOF": while running runtime: exit status 2
ERROR:podman_compose:Build command failed
Error: executing /usr/bin/podman-compose up --build: exit status 2
```
This is because podman uses `/bin/sh` to execute heredocs even when `SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]` is defined. The bash array syntax `PACKAGES=(...)` is not supported in `/bin/sh`.
This PR removes the bash-specific array syntax and lists packages directly in the apt-get install command, making the build process compatible with both docker and podman.