### PR TITLE
fix: assign command could not be found by bsearch

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -42,8 +42,8 @@ struct cmd_results *checkarg(int argc, const char *name, enum expected_args type
 
 /* Keep alphabetized */
 static const struct cmd_handler handlers[] = {
-	{ "assign", cmd_assign },
 	{ "animation_duration_ms", cmd_animation_duration_ms },
+	{ "assign", cmd_assign },
 	{ "bar", cmd_bar },
 	{ "bindcode", cmd_bindcode },
 	{ "bindgesture", cmd_bindgesture },


### PR DESCRIPTION
Hello,
I woke up this morning to swayfx telling me that `assign` was an unknown/invalid command. After a little bit of digging, it turns out that it was because the `animation_duration_ms` wasn't inserted in the lexicographic order in the `handlers` array in `commands.c`, thus preventing `bsearch` from finding the `assign` command.

Glad to finally see animations coming btw!! Thanks for all the work!