### PR TITLE
build: add optional self-contained library resolution for local installs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -197,6 +197,24 @@ else
 	)
 endif
 
+prefix_lib_rpath = ''
+if get_option('self-contained-libs')
+	bindir = get_option('bindir')
+	libdir = get_option('libdir')
+	if not fs.is_absolute(bindir)
+		bindir = join_paths(prefix, bindir)
+	endif
+	if not fs.is_absolute(libdir)
+		libdir = join_paths(prefix, libdir)
+	endif
+
+	libdir_from_bindir = fs.relative_to(libdir, bindir)
+	if fs.is_absolute(libdir_from_bindir)
+		prefix_lib_rpath = libdir_from_bindir
+	else
+		prefix_lib_rpath = join_paths('$ORIGIN', libdir_from_bindir)
+	endif
+endif
 
 sway_inc = include_directories('include')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,4 @@ option('tray', type: 'feature', value: 'auto', description: 'Enable support for 
 option('gdk-pixbuf', type: 'feature', value: 'auto', description: 'Enable support for more image formats in swaybar tray')
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('sd-bus-provider', type: 'combo', choices: ['auto', 'libsystemd', 'libelogind', 'basu'], value: 'auto', description: 'Provider of the sd-bus library')
+option('self-contained-libs', type: 'boolean', value: false, description: 'Prefer libraries installed in the same prefix as the binary')

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -276,5 +276,6 @@ executable(
 	include_directories: [sway_inc],
 	dependencies: sway_deps,
 	link_with: [lib_sway_common],
-	install: true
+	install: true,
+	install_rpath: prefix_lib_rpath
 )


### PR DESCRIPTION

## Summary

Add an optional Meson build option to make local-prefix installs self-contained at runtime:

- `-Dself-contained-libs=true`

When enabled, the `sway` target gets an `install_rpath` derived from Meson’s configured install directories (`bindir` and `libdir`) instead of assuming a fixed `../lib` layout.

## Motivation

For local installs, such as under `~/.local`, `~/.local/bin/sway` can otherwise load an older system `libscenefx-0.4.so` from `/usr/lib` or `/lib` instead of the matching local library from `~/.local/lib`.

This can lead to runtime linker errors when the system library does not provide the symbols expected by the locally built binary.

## Design

This change:

- adds a Meson option:
  - `self-contained-libs` (default: `false`)
- computes the runtime library path from Meson directory options:
  - resolves relative `bindir` and `libdir` against `prefix`
  - uses `fs.relative_to()` when possible
  - falls back to an absolute path when a relative path is not possible
- applies the computed path through:
  - `install_rpath: prefix_lib_rpath`

Default behavior remains unchanged unless the option is explicitly enabled.

## Why this approach

- uses Meson’s built-in `install_rpath` support
- avoids manual linker flags
- avoids hardcoding `../lib`, so it works with `lib`, `lib64`, multiarch layouts, and custom install directory configurations

## Verification

Tested locally with:

```bash
meson setup build --prefix="$HOME/.local" -Dself-contained-libs=true
ninja -C build
ninja -C build install
readelf -d ~/.local/bin/sway | grep -i runpath
ldd ~/.local/bin/sway | grep libscenefx
````

Observed:

* `RUNPATH` is present on the installed `sway` binary (`$ORIGIN/../lib` for this layout)
* `libscenefx-0.4.so` resolves from `~/.local/lib`
* system `/usr/bin/sway` remains unchanged
