### PR TITLE
fix: scope N_CONTAINER case block in transaction_apply

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -909,7 +909,7 @@ static void transaction_apply(struct sway_transaction *transaction) {
 			apply_workspace_state(node->sway_workspace,
 					&instruction->workspace_state);
 			break;
-		case N_CONTAINER:
+		case N_CONTAINER: {
 			struct sway_container *con = node->sway_container;
 			if (should_con_new_animation(con, &instruction->container_state)) {
 				should_start_new_animation = true;
@@ -928,6 +928,7 @@ static void transaction_apply(struct sway_transaction *transaction) {
 			}
 			apply_container_state(con, &instruction->container_state);
 			break;
+		}
 		}
 
 		node->instruction = NULL;


### PR DESCRIPTION
## Summary

Fix a pre-existing syntax issue in `sway/desktop/transaction.c` introduced by `0b7dfdb6` and discovered during a build.

## What changed

Wrap the `N_CONTAINER` switch case in braces so the variable declaration is properly scoped.

## Why

This was discovered while building with stricter C compiler settings. Some compilers reject declarations placed directly after a `case` label.

## Impact

No functional change. This only fixes the syntax so the code builds more reliably.
