### PR TITLE
Implement dbusmenu popup for SNI tray items

### DIFF
--- a/include/swaybar/input.h
+++ b/include/swaybar/input.h
@@ -22,6 +22,7 @@ struct swaybar_pointer {
 	struct wl_cursor_image *cursor_image;
 	struct wl_surface *cursor_surface;
 	struct swaybar_output *current;
+	bool in_menu; // pointer is over the tray popup menu
 	double x, y;
 	uint32_t serial;
 };

--- a/include/swaybar/tray/menu.h
+++ b/include/swaybar/tray/menu.h
@@ -17,18 +17,41 @@ struct swaybar_seat;
 #define MENU_PADDING_Y 4
 #define MENU_SEPARATOR_HEIGHT 9
 #define MENU_MIN_WIDTH 180
+#define MENU_TOGGLE_SIZE 14
+#define MENU_TOGGLE_MARGIN 6
+#define MENU_SUBMENU_ARROW_SIZE 8
 #define MENU_BG_COLOR 0x2E2E3EFF
 #define MENU_BG_HOVER_COLOR 0x4444AAFF
 #define MENU_TEXT_COLOR 0xDDDDDDFF
 #define MENU_TEXT_DISABLED_COLOR 0x777777FF
 #define MENU_SEPARATOR_COLOR 0x555577FF
 #define MENU_BORDER_COLOR 0x6633BBFF
+#define MENU_CHECK_COLOR 0x88CCFFFF
+
+enum menu_toggle_type {
+	MENU_TOGGLE_NONE = 0,
+	MENU_TOGGLE_CHECKMARK,
+	MENU_TOGGLE_RADIO,
+};
+
+enum menu_toggle_state {
+	MENU_TOGGLE_STATE_OFF = 0,
+	MENU_TOGGLE_STATE_ON = 1,
+	MENU_TOGGLE_STATE_INDETERMINATE = -1,
+};
 
 struct swaybar_menu_item {
 	int32_t id;
 	char *label;
+	char *icon_name;
+	uint8_t *icon_data;
+	size_t icon_data_len;
+	cairo_surface_t *icon_surface; // rendered icon cache
 	bool enabled;
 	bool is_separator;
+	bool has_submenu;
+	enum menu_toggle_type toggle_type;
+	enum menu_toggle_state toggle_state;
 };
 
 struct swaybar_menu {
@@ -40,12 +63,20 @@ struct swaybar_menu {
 	struct zwlr_layer_surface_v1 *layer_surface;
 	struct pool_buffer buffers[2];
 
+	// Invisible fullscreen scrim for click-outside-to-dismiss
+	struct wl_surface *scrim_surface;
+	struct zwlr_layer_surface_v1 *scrim_layer_surface;
+	struct pool_buffer scrim_buffers[2];
+	bool scrim_configured;
+
 	struct swaybar_menu_item *items;
 	int item_count;
 	int hovered_index; // -1 for none
 
 	uint32_t width, height;
 	int anchor_x; // x position of the tray icon that spawned this menu
+	int toggle_column_width;  // extra left margin for toggle indicators
+	int submenu_column_width; // extra right margin for submenu arrows
 	bool configured;
 	bool dirty;
 };
@@ -66,6 +97,8 @@ bool tray_menu_is_open(struct swaybar_menu *menu);
 
 // Input handling - returns true if the event was consumed
 bool tray_menu_pointer_enter(struct swaybar_menu *menu,
+		struct wl_surface *surface);
+bool tray_menu_is_scrim(struct swaybar_menu *menu,
 		struct wl_surface *surface);
 void tray_menu_pointer_motion(struct swaybar_menu *menu, double x, double y);
 bool tray_menu_pointer_button(struct swaybar_menu *menu, uint32_t button,

--- a/include/swaybar/tray/menu.h
+++ b/include/swaybar/tray/menu.h
@@ -76,6 +76,7 @@ struct swaybar_menu {
 	uint32_t width, height;
 	int anchor_x; // x position of the tray icon that spawned this menu
 	int toggle_column_width;  // extra left margin for toggle indicators
+	int icon_column_width;    // extra left margin for icons
 	int submenu_column_width; // extra right margin for submenu arrows
 	bool configured;
 	bool dirty;
@@ -88,6 +89,9 @@ void tray_menu_destroy(struct swaybar_menu *menu);
 // Open the menu for a given SNI at the given position
 void tray_menu_open(struct swaybar_menu *menu, struct swaybar_sni *sni,
 		struct swaybar_output *output, int anchor_x);
+
+// Track that a native ContextMenu was opened (no scrim, just state tracking)
+// -- removed, now using dbusmenu popup for all SNIs with Menu property
 
 // Close the menu if open
 void tray_menu_close(struct swaybar_menu *menu);

--- a/include/swaybar/tray/menu.h
+++ b/include/swaybar/tray/menu.h
@@ -1,0 +1,78 @@
+#ifndef _SWAYBAR_TRAY_MENU_H
+#define _SWAYBAR_TRAY_MENU_H
+
+#include <cairo.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <wayland-client.h>
+#include "pool-buffer.h"
+
+struct swaybar;
+struct swaybar_output;
+struct swaybar_sni;
+struct swaybar_seat;
+
+#define MENU_ITEM_HEIGHT 28
+#define MENU_PADDING_X 12
+#define MENU_PADDING_Y 4
+#define MENU_SEPARATOR_HEIGHT 9
+#define MENU_MIN_WIDTH 180
+#define MENU_BG_COLOR 0x2E2E3EFF
+#define MENU_BG_HOVER_COLOR 0x4444AAFF
+#define MENU_TEXT_COLOR 0xDDDDDDFF
+#define MENU_TEXT_DISABLED_COLOR 0x777777FF
+#define MENU_SEPARATOR_COLOR 0x555577FF
+#define MENU_BORDER_COLOR 0x6633BBFF
+
+struct swaybar_menu_item {
+	int32_t id;
+	char *label;
+	bool enabled;
+	bool is_separator;
+};
+
+struct swaybar_menu {
+	struct swaybar *bar;
+	struct swaybar_output *output;
+	struct swaybar_sni *sni;
+
+	struct wl_surface *surface;
+	struct zwlr_layer_surface_v1 *layer_surface;
+	struct pool_buffer buffers[2];
+
+	struct swaybar_menu_item *items;
+	int item_count;
+	int hovered_index; // -1 for none
+
+	uint32_t width, height;
+	int anchor_x; // x position of the tray icon that spawned this menu
+	bool configured;
+	bool dirty;
+};
+
+// Global menu state (only one menu open at a time)
+struct swaybar_menu *tray_menu_create(struct swaybar *bar);
+void tray_menu_destroy(struct swaybar_menu *menu);
+
+// Open the menu for a given SNI at the given position
+void tray_menu_open(struct swaybar_menu *menu, struct swaybar_sni *sni,
+		struct swaybar_output *output, int anchor_x);
+
+// Close the menu if open
+void tray_menu_close(struct swaybar_menu *menu);
+
+// Returns true if the menu is currently open
+bool tray_menu_is_open(struct swaybar_menu *menu);
+
+// Input handling - returns true if the event was consumed
+bool tray_menu_pointer_enter(struct swaybar_menu *menu,
+		struct wl_surface *surface);
+void tray_menu_pointer_motion(struct swaybar_menu *menu, double x, double y);
+bool tray_menu_pointer_button(struct swaybar_menu *menu, uint32_t button,
+		uint32_t state);
+void tray_menu_pointer_leave(struct swaybar_menu *menu);
+
+// Render the menu
+void tray_menu_render(struct swaybar_menu *menu);
+
+#endif

--- a/include/swaybar/tray/tray.h
+++ b/include/swaybar/tray/tray.h
@@ -17,6 +17,7 @@
 struct swaybar;
 struct swaybar_output;
 struct swaybar_watcher;
+struct swaybar_menu;
 
 struct swaybar_tray {
 	struct swaybar *bar;
@@ -32,6 +33,8 @@ struct swaybar_tray {
 
 	list_t *basedirs; // char *
 	list_t *themes; // struct swaybar_theme *
+
+	struct swaybar_menu *menu;
 };
 
 struct swaybar_tray *create_tray(struct swaybar *bar);

--- a/swaybar/input.c
+++ b/swaybar/input.c
@@ -9,6 +9,10 @@
 #include "swaybar/config.h"
 #include "swaybar/input.h"
 #include "swaybar/ipc.h"
+#if HAVE_TRAY
+#include "swaybar/tray/tray.h"
+#include "swaybar/tray/menu.h"
+#endif
 
 void free_hotspots(struct wl_list *list) {
 	struct swaybar_hotspot *hotspot, *tmp;
@@ -112,6 +116,29 @@ static void wl_pointer_enter(void *data, struct wl_pointer *wl_pointer,
 	seat->pointer.x = wl_fixed_to_double(surface_x);
 	seat->pointer.y = wl_fixed_to_double(surface_y);
 
+#if HAVE_TRAY
+	if (seat->bar->tray && seat->bar->tray->menu &&
+			tray_menu_pointer_enter(seat->bar->tray->menu, surface)) {
+		pointer->in_menu = true;
+		tray_menu_pointer_motion(seat->bar->tray->menu,
+				pointer->x, pointer->y);
+		// Still set cursor
+		if (seat->bar->cursor_shape_manager) {
+			struct wp_cursor_shape_device_v1 *device =
+				wp_cursor_shape_manager_v1_get_pointer(
+					seat->bar->cursor_shape_manager, wl_pointer);
+			wp_cursor_shape_device_v1_set_shape(device, serial,
+				WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_DEFAULT);
+			wp_cursor_shape_device_v1_destroy(device);
+		} else {
+			pointer->serial = serial;
+			update_cursor(seat);
+		}
+		return;
+	}
+	pointer->in_menu = false;
+#endif
+
 	struct swaybar_output *output;
 	wl_list_for_each(output, &seat->bar->outputs, link) {
 		if (output->surface == surface) {
@@ -136,6 +163,13 @@ static void wl_pointer_enter(void *data, struct wl_pointer *wl_pointer,
 static void wl_pointer_leave(void *data, struct wl_pointer *wl_pointer,
 		uint32_t serial, struct wl_surface *surface) {
 	struct swaybar_seat *seat = data;
+#if HAVE_TRAY
+	if (seat->pointer.in_menu && seat->bar->tray && seat->bar->tray->menu) {
+		tray_menu_pointer_leave(seat->bar->tray->menu);
+		seat->pointer.in_menu = false;
+		return;
+	}
+#endif
 	seat->pointer.current = NULL;
 }
 
@@ -144,6 +178,12 @@ static void wl_pointer_motion(void *data, struct wl_pointer *wl_pointer,
 	struct swaybar_seat *seat = data;
 	seat->pointer.x = wl_fixed_to_double(surface_x);
 	seat->pointer.y = wl_fixed_to_double(surface_y);
+#if HAVE_TRAY
+	if (seat->pointer.in_menu && seat->bar->tray && seat->bar->tray->menu) {
+		tray_menu_pointer_motion(seat->bar->tray->menu,
+				seat->pointer.x, seat->pointer.y);
+	}
+#endif
 }
 
 static bool check_bindings(struct swaybar *bar, uint32_t button,
@@ -181,6 +221,20 @@ static void wl_pointer_button(void *data, struct wl_pointer *wl_pointer,
 		uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
 	struct swaybar_seat *seat = data;
 	struct swaybar_pointer *pointer = &seat->pointer;
+
+#if HAVE_TRAY
+	if (pointer->in_menu && seat->bar->tray && seat->bar->tray->menu) {
+		tray_menu_pointer_button(seat->bar->tray->menu, button, state);
+		return;
+	}
+	// If clicking on the bar while a menu is open, close the menu
+	if (seat->bar->tray && seat->bar->tray->menu &&
+			tray_menu_is_open(seat->bar->tray->menu) &&
+			state == WL_POINTER_BUTTON_STATE_PRESSED) {
+		tray_menu_close(seat->bar->tray->menu);
+	}
+#endif
+
 	struct swaybar_output *output = pointer->current;
 	if (!sway_assert(output, "button with no active output")) {
 		return;

--- a/swaybar/input.c
+++ b/swaybar/input.c
@@ -136,6 +136,23 @@ static void wl_pointer_enter(void *data, struct wl_pointer *wl_pointer,
 		}
 		return;
 	}
+	// Check if pointer entered the scrim (click-outside dismiss surface)
+	if (seat->bar->tray && seat->bar->tray->menu &&
+			tray_menu_is_scrim(seat->bar->tray->menu, surface)) {
+		pointer->in_menu = true; // reuse flag; scrim clicks dismiss
+		if (seat->bar->cursor_shape_manager) {
+			struct wp_cursor_shape_device_v1 *device =
+				wp_cursor_shape_manager_v1_get_pointer(
+					seat->bar->cursor_shape_manager, wl_pointer);
+			wp_cursor_shape_device_v1_set_shape(device, serial,
+				WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_DEFAULT);
+			wp_cursor_shape_device_v1_destroy(device);
+		} else {
+			pointer->serial = serial;
+			update_cursor(seat);
+		}
+		return;
+	}
 	pointer->in_menu = false;
 #endif
 

--- a/swaybar/meson.build
+++ b/swaybar/meson.build
@@ -2,6 +2,7 @@ tray_files = have_tray ? [
 	'tray/host.c',
 	'tray/icon.c',
 	'tray/item.c',
+	'tray/menu.c',
 	'tray/tray.c',
 	'tray/watcher.c'
 ] : []

--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -499,9 +499,9 @@ static void handle_click(struct swaybar_sni *sni, int x, int y,
 	} else {
 		if (sni_is_ayatana(sni) && strcmp(method, "Activate") == 0) {
 			sni_activate_via_dbusmenu(sni, "Activate");
-		} else if (strcmp(method, "ContextMenu") == 0 && sni->menu &&
-				sni->tray->menu) {
-			// Open popup menu for ContextMenu if dbusmenu is available
+		} else if (strcmp(method, "ContextMenu") == 0 && sni_is_ayatana(sni)
+				&& sni->menu && sni->tray->menu) {
+			// Ayatana items lack native ContextMenu — use dbusmenu popup fallback
 			struct swaybar_output *output;
 			wl_list_for_each(output, &sni->tray->bar->outputs, link) {
 				// Use the first visible output (the one the bar is on)

--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -11,6 +11,7 @@
 #include "swaybar/tray/host.h"
 #include "swaybar/tray/icon.h"
 #include "swaybar/tray/item.h"
+#include "swaybar/tray/menu.h"
 #include "swaybar/tray/tray.h"
 #include "cairo_util.h"
 #include "list.h"
@@ -18,7 +19,130 @@
 #include "stringop.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 
-// TODO menu
+// dbusmenu fallback when Activate/ContextMenu methods are missing
+// (e.g. Steam's ayatana/libappindicator interface)
+
+static bool sni_is_ayatana(struct swaybar_sni *sni) {
+	return sni->path && strstr(sni->path, "ayatana") != NULL;
+}
+
+static int handle_get_layout_reply(sd_bus_message *msg, void *userdata,
+		sd_bus_error *error) {
+	struct swaybar_sni *sni = userdata;
+
+	if (sd_bus_message_is_method_error(msg, NULL)) {
+		const sd_bus_error *err = sd_bus_message_get_error(msg);
+		sway_log(SWAY_ERROR, "%s: dbusmenu GetLayout failed: %s",
+				sni->watcher_id, err->message);
+		return -1;
+	}
+
+	uint32_t revision;
+	int ret = sd_bus_message_read(msg, "u", &revision);
+	if (ret < 0) return ret;
+
+	// Enter root struct (ia{sv}av)
+	ret = sd_bus_message_enter_container(msg, 'r', "ia{sv}av");
+	if (ret < 0) return ret;
+
+	int32_t root_id;
+	sd_bus_message_read(msg, "i", &root_id);
+
+	// Skip root properties
+	sd_bus_message_enter_container(msg, 'a', "{sv}");
+	while (sd_bus_message_enter_container(msg, 'e', "sv") > 0) {
+		sd_bus_message_skip(msg, "sv");
+		sd_bus_message_exit_container(msg);
+	}
+	sd_bus_message_exit_container(msg);
+
+	// Enter children array
+	ret = sd_bus_message_enter_container(msg, 'a', "v");
+	if (ret < 0) return ret;
+
+	// Look for first non-separator item after a separator (Store/Library section)
+	bool found_separator = false;
+	int32_t target_id = -1;
+	while (sd_bus_message_enter_container(msg, 'v', "(ia{sv}av)") > 0) {
+		sd_bus_message_enter_container(msg, 'r', "ia{sv}av");
+		int32_t item_id;
+		sd_bus_message_read(msg, "i", &item_id);
+
+		// Read properties
+		sd_bus_message_enter_container(msg, 'a', "{sv}");
+		bool is_separator = false;
+		const char *label = NULL;
+		while (sd_bus_message_enter_container(msg, 'e', "sv") > 0) {
+			const char *prop;
+			sd_bus_message_read(msg, "s", &prop);
+			if (strcmp(prop, "type") == 0) {
+				const char *val;
+				if (sd_bus_message_enter_container(msg, 'v', "s") >= 0) {
+					sd_bus_message_read(msg, "s", &val);
+					if (strcmp(val, "separator") == 0) is_separator = true;
+					sd_bus_message_exit_container(msg);
+				} else {
+					sd_bus_message_skip(msg, "v");
+				}
+			} else if (strcmp(prop, "label") == 0) {
+				if (sd_bus_message_enter_container(msg, 'v', "s") >= 0) {
+					sd_bus_message_read(msg, "s", &label);
+					sd_bus_message_exit_container(msg);
+				} else {
+					sd_bus_message_skip(msg, "v");
+				}
+			} else {
+				sd_bus_message_skip(msg, "v");
+			}
+			sd_bus_message_exit_container(msg);
+		}
+		sd_bus_message_exit_container(msg); // a{sv}
+
+		if (is_separator) {
+			found_separator = true;
+		} else if (found_separator && target_id < 0 && label) {
+			// First non-separator after first separator = Store/Library section
+			target_id = item_id;
+			sway_log(SWAY_INFO, "%s: dbusmenu activate target: id=%d label='%s'",
+					sni->watcher_id, item_id, label);
+		}
+
+		// Skip children
+		sd_bus_message_skip(msg, "av");
+		sd_bus_message_exit_container(msg); // (ia{sv}av)
+		sd_bus_message_exit_container(msg); // v
+	}
+
+	if (target_id >= 0) {
+		sd_bus_call_method_async(sni->tray->bus, NULL, sni->service,
+				sni->menu, "com.canonical.dbusmenu", "Event",
+				NULL, NULL, "isvu", target_id, "clicked", "s", "",
+				(uint32_t)0);
+	} else {
+		sway_log(SWAY_ERROR, "%s: no suitable dbusmenu item found", sni->watcher_id);
+	}
+
+	return 0;
+}
+
+static void sni_activate_via_dbusmenu(struct swaybar_sni *sni, const char *method) {
+	if (!sni->menu) {
+		sway_log(SWAY_ERROR, "%s: no dbusmenu path for fallback", sni->watcher_id);
+		return;
+	}
+
+	sway_log(SWAY_INFO, "%s: ayatana %s via dbusmenu", sni->watcher_id, method);
+
+	// Prime the menu
+	sd_bus_call_method_async(sni->tray->bus, NULL, sni->service,
+			sni->menu, "com.canonical.dbusmenu", "AboutToShow",
+			NULL, NULL, "i", (int32_t)0);
+
+	// Query menu layout and click the first actionable item (Store/Library)
+	sd_bus_call_method_async(sni->tray->bus, NULL, sni->service,
+			sni->menu, "com.canonical.dbusmenu", "GetLayout",
+			handle_get_layout_reply, sni, "iias", (int32_t)0, (int32_t)1, 0);
+}
 
 static bool sni_ready(struct swaybar_sni *sni) {
 	return sni->status && (sni->status[0] == 'N' ? // NeedsAttention
@@ -373,8 +497,24 @@ static void handle_click(struct swaybar_sni *sni, int x, int y,
 		sd_bus_call_method_async(sni->tray->bus, NULL, sni->service, sni->path,
 				sni->interface, "Scroll", NULL, NULL, "is", delta*sign, orientation);
 	} else {
-		sd_bus_call_method_async(sni->tray->bus, NULL, sni->service, sni->path,
-				sni->interface, method, NULL, NULL, "ii", x, y);
+		if (sni_is_ayatana(sni) && strcmp(method, "Activate") == 0) {
+			sni_activate_via_dbusmenu(sni, "Activate");
+		} else if (strcmp(method, "ContextMenu") == 0 && sni->menu &&
+				sni->tray->menu) {
+			// Open popup menu for ContextMenu if dbusmenu is available
+			struct swaybar_output *output;
+			wl_list_for_each(output, &sni->tray->bar->outputs, link) {
+				// Use the first visible output (the one the bar is on)
+				// The caller passes global coords so we use those to guess output
+				if (output->surface) {
+					tray_menu_open(sni->tray->menu, sni, output, x);
+					break;
+				}
+			}
+		} else {
+			sd_bus_call_method_async(sni->tray->bus, NULL, sni->service,
+					sni->path, sni->interface, method, NULL, NULL, "ii", x, y);
+		}
 	}
 }
 

--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -499,13 +499,11 @@ static void handle_click(struct swaybar_sni *sni, int x, int y,
 	} else {
 		if (sni_is_ayatana(sni) && strcmp(method, "Activate") == 0) {
 			sni_activate_via_dbusmenu(sni, "Activate");
-		} else if (strcmp(method, "ContextMenu") == 0 && sni_is_ayatana(sni)
+		} else if (strcmp(method, "ContextMenu") == 0
 				&& sni->menu && sni->tray->menu) {
-			// Ayatana items lack native ContextMenu — use dbusmenu popup fallback
+			// Use our dbusmenu popup for any SNI that has a Menu path
 			struct swaybar_output *output;
 			wl_list_for_each(output, &sni->tray->bar->outputs, link) {
-				// Use the first visible output (the one the bar is on)
-				// The caller passes global coords so we use those to guess output
 				if (output->surface) {
 					tray_menu_open(sni->tray->menu, sni, output, x);
 					break;

--- a/swaybar/tray/menu.c
+++ b/swaybar/tray/menu.c
@@ -20,6 +20,54 @@
 #include "pool-buffer.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 
+#define MENU_ICON_SIZE 16
+
+struct png_read_closure {
+	const uint8_t *data;
+	size_t len;
+	size_t pos;
+};
+
+static cairo_status_t png_read_func(void *closure, unsigned char *data,
+		unsigned int length) {
+	struct png_read_closure *rc = closure;
+	if (rc->pos + length > rc->len) {
+		return CAIRO_STATUS_READ_ERROR;
+	}
+	memcpy(data, rc->data + rc->pos, length);
+	rc->pos += length;
+	return CAIRO_STATUS_SUCCESS;
+}
+
+static cairo_surface_t *decode_icon_data(const uint8_t *data, size_t len) {
+	// Try loading as PNG directly via cairo
+	struct png_read_closure rc = { .data = data, .len = len, .pos = 0 };
+	cairo_surface_t *surface = cairo_image_surface_create_from_png_stream(
+			png_read_func, &rc);
+	if (!surface || cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) {
+		if (surface) cairo_surface_destroy(surface);
+		return NULL;
+	}
+
+	int w = cairo_image_surface_get_width(surface);
+	int h = cairo_image_surface_get_height(surface);
+
+	// Scale if needed
+	if (w != MENU_ICON_SIZE || h != MENU_ICON_SIZE) {
+		cairo_surface_t *scaled = cairo_image_surface_create(
+				CAIRO_FORMAT_ARGB32, MENU_ICON_SIZE, MENU_ICON_SIZE);
+		cairo_t *cr = cairo_create(scaled);
+		cairo_scale(cr, (double)MENU_ICON_SIZE / w, (double)MENU_ICON_SIZE / h);
+		cairo_set_source_surface(cr, surface, 0, 0);
+		cairo_paint(cr);
+		cairo_destroy(cr);
+		cairo_surface_destroy(surface);
+		surface = scaled;
+	}
+
+	return surface;
+}
+
 static void menu_layer_surface_configure(void *data,
 		struct zwlr_layer_surface_v1 *surface,
 		uint32_t serial, uint32_t width, uint32_t height) {
@@ -76,6 +124,31 @@ static const struct zwlr_layer_surface_v1_listener scrim_layer_surface_listener 
 	.configure = scrim_layer_surface_configure,
 	.closed = scrim_layer_surface_closed,
 };
+
+static void create_scrim(struct swaybar_menu *menu) {
+	if (menu->scrim_surface) {
+		return;
+	}
+	menu->scrim_surface = wl_compositor_create_surface(menu->bar->compositor);
+	assert(menu->scrim_surface);
+
+	menu->scrim_layer_surface = zwlr_layer_shell_v1_get_layer_surface(
+			menu->bar->layer_shell, menu->scrim_surface, menu->output->output,
+			ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY, "menu-scrim");
+	assert(menu->scrim_layer_surface);
+
+	zwlr_layer_surface_v1_add_listener(menu->scrim_layer_surface,
+			&scrim_layer_surface_listener, menu);
+	zwlr_layer_surface_v1_set_anchor(menu->scrim_layer_surface,
+			ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
+			ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM |
+			ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT |
+			ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
+	zwlr_layer_surface_v1_set_exclusive_zone(menu->scrim_layer_surface, -1);
+	zwlr_layer_surface_v1_set_keyboard_interactivity(menu->scrim_layer_surface,
+			ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE);
+	wl_surface_commit(menu->scrim_surface);
+}
 
 struct swaybar_menu *tray_menu_create(struct swaybar *bar) {
 	struct swaybar_menu *menu = calloc(1, sizeof(struct swaybar_menu));
@@ -310,9 +383,10 @@ static int handle_menu_layout(sd_bus_message *msg, void *userdata,
 
 	sway_log(SWAY_DEBUG, "dbusmenu: loaded %d menu items", count);
 
-	// Determine if any items have toggles (affects left margin for all items)
+	// Determine if any items have toggles or icons (affects left margin)
 	bool has_any_toggle = false;
 	bool has_any_submenu = false;
+	bool has_any_icon = false;
 	for (int i = 0; i < count; i++) {
 		if (items[i].toggle_type != MENU_TOGGLE_NONE) {
 			has_any_toggle = true;
@@ -320,15 +394,29 @@ static int handle_menu_layout(sd_bus_message *msg, void *userdata,
 		if (items[i].has_submenu) {
 			has_any_submenu = true;
 		}
+		if (items[i].icon_data && items[i].icon_data_len > 0) {
+			has_any_icon = true;
+		}
 	}
 
-	// Compute left text offset: padding + optional toggle column
+	// Decode icon data into cairo surfaces
+	for (int i = 0; i < count; i++) {
+		if (items[i].icon_data && items[i].icon_data_len > 0 && !items[i].icon_surface) {
+			items[i].icon_surface = decode_icon_data(items[i].icon_data,
+					items[i].icon_data_len);
+		}
+	}
+
+	// Compute left text offset: padding + optional toggle column + optional icon column
 	int toggle_column_width = has_any_toggle ?
 			(MENU_TOGGLE_SIZE + MENU_TOGGLE_MARGIN) : 0;
+	int icon_column_width = has_any_icon ?
+			(MENU_ICON_SIZE + MENU_TOGGLE_MARGIN) : 0;
 	int submenu_column_width = has_any_submenu ?
 			(MENU_SUBMENU_ARROW_SIZE + MENU_TOGGLE_MARGIN) : 0;
 
 	menu->toggle_column_width = toggle_column_width;
+	menu->icon_column_width = icon_column_width;
 	menu->submenu_column_width = submenu_column_width;
 
 	// Now compute size and create/show the surface
@@ -366,7 +454,7 @@ static int handle_menu_layout(sd_bus_message *msg, void *userdata,
 		total_height += items[i].is_separator ? MENU_SEPARATOR_HEIGHT : MENU_ITEM_HEIGHT;
 	}
 	int total_width = max_text_width + MENU_PADDING_X * 2
-			+ toggle_column_width + submenu_column_width;
+			+ toggle_column_width + icon_column_width + submenu_column_width;
 
 	// Create the layer surface
 	if (menu->layer_surface) {
@@ -374,26 +462,8 @@ static int handle_menu_layout(sd_bus_message *msg, void *userdata,
 		zwlr_layer_surface_v1_set_size(menu->layer_surface, total_width, total_height);
 		wl_surface_commit(menu->surface);
 	} else {
-		// Create scrim (invisible fullscreen surface) first, so it's below the menu
-		menu->scrim_surface = wl_compositor_create_surface(menu->bar->compositor);
-		assert(menu->scrim_surface);
-
-		menu->scrim_layer_surface = zwlr_layer_shell_v1_get_layer_surface(
-				menu->bar->layer_shell, menu->scrim_surface, menu->output->output,
-				ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY, "menu-scrim");
-		assert(menu->scrim_layer_surface);
-
-		zwlr_layer_surface_v1_add_listener(menu->scrim_layer_surface,
-				&scrim_layer_surface_listener, menu);
-		zwlr_layer_surface_v1_set_anchor(menu->scrim_layer_surface,
-				ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
-				ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM |
-				ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT |
-				ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
-		zwlr_layer_surface_v1_set_exclusive_zone(menu->scrim_layer_surface, -1);
-		zwlr_layer_surface_v1_set_keyboard_interactivity(menu->scrim_layer_surface,
-				ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE);
-		wl_surface_commit(menu->scrim_surface);
+		// Create scrim first, so it's below the menu
+		create_scrim(menu);
 
 		// Create the actual menu surface
 		menu->surface = wl_compositor_create_surface(menu->bar->compositor);
@@ -646,6 +716,7 @@ void tray_menu_render(struct swaybar_menu *menu) {
 
 	double y = MENU_PADDING_Y;
 	int tcw = menu->toggle_column_width;
+	int icw = menu->icon_column_width;
 
 	for (int i = 0; i < menu->item_count; i++) {
 		struct swaybar_menu_item *item = &menu->items[i];
@@ -668,7 +739,15 @@ void tray_menu_render(struct swaybar_menu *menu) {
 			cairo_fill(cairo);
 		}
 
-		double text_x = MENU_PADDING_X + tcw;
+		double text_x = MENU_PADDING_X + tcw + icw;
+
+		// Draw icon
+		if (item->icon_surface && icw > 0) {
+			double icon_x = MENU_PADDING_X + tcw;
+			double icon_y = y + (MENU_ITEM_HEIGHT - MENU_ICON_SIZE) / 2.0;
+			cairo_set_source_surface(cairo, item->icon_surface, icon_x, icon_y);
+			cairo_paint(cairo);
+		}
 
 		// Draw toggle indicator
 		if (item->toggle_type != MENU_TOGGLE_NONE) {

--- a/swaybar/tray/menu.c
+++ b/swaybar/tray/menu.c
@@ -42,6 +42,41 @@ static const struct zwlr_layer_surface_v1_listener menu_layer_surface_listener =
 	.closed = menu_layer_surface_closed,
 };
 
+static void scrim_layer_surface_configure(void *data,
+		struct zwlr_layer_surface_v1 *surface,
+		uint32_t serial, uint32_t width, uint32_t height) {
+	struct swaybar_menu *menu = data;
+	menu->scrim_configured = true;
+	zwlr_layer_surface_v1_ack_configure(surface, serial);
+
+	// Render a fully transparent 1x1 buffer
+	int scale = menu->output ? menu->output->scale : 1;
+	struct pool_buffer *buffer = get_next_buffer(menu->bar->shm,
+			menu->scrim_buffers, width * scale, height * scale);
+	if (buffer) {
+		cairo_t *cr = buffer->cairo;
+		cairo_save(cr);
+		cairo_set_operator(cr, CAIRO_OPERATOR_CLEAR);
+		cairo_paint(cr);
+		cairo_restore(cr);
+		wl_surface_set_buffer_scale(menu->scrim_surface, scale);
+		wl_surface_attach(menu->scrim_surface, buffer->buffer, 0, 0);
+		wl_surface_damage(menu->scrim_surface, 0, 0, width, height);
+		wl_surface_commit(menu->scrim_surface);
+	}
+}
+
+static void scrim_layer_surface_closed(void *data,
+		struct zwlr_layer_surface_v1 *surface) {
+	struct swaybar_menu *menu = data;
+	tray_menu_close(menu);
+}
+
+static const struct zwlr_layer_surface_v1_listener scrim_layer_surface_listener = {
+	.configure = scrim_layer_surface_configure,
+	.closed = scrim_layer_surface_closed,
+};
+
 struct swaybar_menu *tray_menu_create(struct swaybar *bar) {
 	struct swaybar_menu *menu = calloc(1, sizeof(struct swaybar_menu));
 	if (!menu) {
@@ -64,6 +99,11 @@ static void menu_clear_items(struct swaybar_menu *menu) {
 	if (menu->items) {
 		for (int i = 0; i < menu->item_count; i++) {
 			free(menu->items[i].label);
+			free(menu->items[i].icon_name);
+			free(menu->items[i].icon_data);
+			if (menu->items[i].icon_surface) {
+				cairo_surface_destroy(menu->items[i].icon_surface);
+			}
 		}
 		free(menu->items);
 		menu->items = NULL;
@@ -121,9 +161,15 @@ static int handle_menu_layout(sd_bus_message *msg, void *userdata,
 		sd_bus_message_read(msg, "i", &item_id);
 
 		char *label = NULL;
+		char *icon_name = NULL;
+		uint8_t *icon_data = NULL;
+		size_t icon_data_len = 0;
 		bool is_separator = false;
 		bool enabled = true;
 		bool visible = true;
+		bool has_submenu = false;
+		enum menu_toggle_type toggle_type = MENU_TOGGLE_NONE;
+		enum menu_toggle_state toggle_state = MENU_TOGGLE_STATE_OFF;
 
 		sd_bus_message_enter_container(msg, 'a', "{sv}");
 		while (sd_bus_message_enter_container(msg, 'e', "sv") > 0) {
@@ -168,6 +214,65 @@ static int handle_menu_layout(sd_bus_message *msg, void *userdata,
 				} else {
 					sd_bus_message_skip(msg, "v");
 				}
+			} else if (strcmp(prop, "toggle-type") == 0) {
+				if (sd_bus_message_enter_container(msg, 'v', "s") >= 0) {
+					const char *val;
+					sd_bus_message_read(msg, "s", &val);
+					if (strcmp(val, "checkmark") == 0) {
+						toggle_type = MENU_TOGGLE_CHECKMARK;
+					} else if (strcmp(val, "radio") == 0) {
+						toggle_type = MENU_TOGGLE_RADIO;
+					}
+					sd_bus_message_exit_container(msg);
+				} else {
+					sd_bus_message_skip(msg, "v");
+				}
+			} else if (strcmp(prop, "toggle-state") == 0) {
+				if (sd_bus_message_enter_container(msg, 'v', "i") >= 0) {
+					int32_t val;
+					sd_bus_message_read(msg, "i", &val);
+					toggle_state = (enum menu_toggle_state)val;
+					sd_bus_message_exit_container(msg);
+				} else {
+					sd_bus_message_skip(msg, "v");
+				}
+			} else if (strcmp(prop, "icon-name") == 0) {
+				if (sd_bus_message_enter_container(msg, 'v', "s") >= 0) {
+					const char *val;
+					sd_bus_message_read(msg, "s", &val);
+					if (val && val[0]) {
+						icon_name = strdup(val);
+					}
+					sd_bus_message_exit_container(msg);
+				} else {
+					sd_bus_message_skip(msg, "v");
+				}
+			} else if (strcmp(prop, "icon-data") == 0) {
+				if (sd_bus_message_enter_container(msg, 'v', "ay") >= 0) {
+					const void *data;
+					size_t len;
+					if (sd_bus_message_read_array(msg, 'y', &data, &len) >= 0 && len > 0) {
+						icon_data = malloc(len);
+						if (icon_data) {
+							memcpy(icon_data, data, len);
+							icon_data_len = len;
+						}
+					}
+					sd_bus_message_exit_container(msg);
+				} else {
+					sd_bus_message_skip(msg, "v");
+				}
+			} else if (strcmp(prop, "children-display") == 0) {
+				if (sd_bus_message_enter_container(msg, 'v', "s") >= 0) {
+					const char *val;
+					sd_bus_message_read(msg, "s", &val);
+					if (val && strcmp(val, "submenu") == 0) {
+						has_submenu = true;
+					}
+					sd_bus_message_exit_container(msg);
+				} else {
+					sd_bus_message_skip(msg, "v");
+				}
 			} else {
 				sd_bus_message_skip(msg, "v");
 			}
@@ -185,9 +290,18 @@ static int handle_menu_layout(sd_bus_message *msg, void *userdata,
 			items[count].label = label ? label : (is_separator ? NULL : strdup("???"));
 			items[count].is_separator = is_separator;
 			items[count].enabled = enabled && !is_separator;
+			items[count].toggle_type = toggle_type;
+			items[count].toggle_state = toggle_state;
+			items[count].icon_name = icon_name;
+			items[count].icon_data = icon_data;
+			items[count].icon_data_len = icon_data_len;
+			items[count].icon_surface = NULL;
+			items[count].has_submenu = has_submenu;
 			count++;
 		} else {
 			free(label);
+			free(icon_name);
+			free(icon_data);
 		}
 	}
 
@@ -195,6 +309,27 @@ static int handle_menu_layout(sd_bus_message *msg, void *userdata,
 	menu->item_count = count;
 
 	sway_log(SWAY_DEBUG, "dbusmenu: loaded %d menu items", count);
+
+	// Determine if any items have toggles (affects left margin for all items)
+	bool has_any_toggle = false;
+	bool has_any_submenu = false;
+	for (int i = 0; i < count; i++) {
+		if (items[i].toggle_type != MENU_TOGGLE_NONE) {
+			has_any_toggle = true;
+		}
+		if (items[i].has_submenu) {
+			has_any_submenu = true;
+		}
+	}
+
+	// Compute left text offset: padding + optional toggle column
+	int toggle_column_width = has_any_toggle ?
+			(MENU_TOGGLE_SIZE + MENU_TOGGLE_MARGIN) : 0;
+	int submenu_column_width = has_any_submenu ?
+			(MENU_SUBMENU_ARROW_SIZE + MENU_TOGGLE_MARGIN) : 0;
+
+	menu->toggle_column_width = toggle_column_width;
+	menu->submenu_column_width = submenu_column_width;
 
 	// Now compute size and create/show the surface
 	int max_text_width = MENU_MIN_WIDTH;
@@ -230,7 +365,8 @@ static int handle_menu_layout(sd_bus_message *msg, void *userdata,
 	for (int i = 0; i < count; i++) {
 		total_height += items[i].is_separator ? MENU_SEPARATOR_HEIGHT : MENU_ITEM_HEIGHT;
 	}
-	int total_width = max_text_width + MENU_PADDING_X * 2;
+	int total_width = max_text_width + MENU_PADDING_X * 2
+			+ toggle_column_width + submenu_column_width;
 
 	// Create the layer surface
 	if (menu->layer_surface) {
@@ -238,6 +374,28 @@ static int handle_menu_layout(sd_bus_message *msg, void *userdata,
 		zwlr_layer_surface_v1_set_size(menu->layer_surface, total_width, total_height);
 		wl_surface_commit(menu->surface);
 	} else {
+		// Create scrim (invisible fullscreen surface) first, so it's below the menu
+		menu->scrim_surface = wl_compositor_create_surface(menu->bar->compositor);
+		assert(menu->scrim_surface);
+
+		menu->scrim_layer_surface = zwlr_layer_shell_v1_get_layer_surface(
+				menu->bar->layer_shell, menu->scrim_surface, menu->output->output,
+				ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY, "menu-scrim");
+		assert(menu->scrim_layer_surface);
+
+		zwlr_layer_surface_v1_add_listener(menu->scrim_layer_surface,
+				&scrim_layer_surface_listener, menu);
+		zwlr_layer_surface_v1_set_anchor(menu->scrim_layer_surface,
+				ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
+				ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM |
+				ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT |
+				ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
+		zwlr_layer_surface_v1_set_exclusive_zone(menu->scrim_layer_surface, -1);
+		zwlr_layer_surface_v1_set_keyboard_interactivity(menu->scrim_layer_surface,
+				ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE);
+		wl_surface_commit(menu->scrim_surface);
+
+		// Create the actual menu surface
 		menu->surface = wl_compositor_create_surface(menu->bar->compositor);
 		assert(menu->surface);
 
@@ -334,8 +492,19 @@ void tray_menu_close(struct swaybar_menu *menu) {
 		menu->surface = NULL;
 	}
 
+	if (menu->scrim_layer_surface) {
+		zwlr_layer_surface_v1_destroy(menu->scrim_layer_surface);
+		menu->scrim_layer_surface = NULL;
+	}
+	if (menu->scrim_surface) {
+		wl_surface_destroy(menu->scrim_surface);
+		menu->scrim_surface = NULL;
+	}
+
 	destroy_buffer(&menu->buffers[0]);
 	destroy_buffer(&menu->buffers[1]);
+	destroy_buffer(&menu->scrim_buffers[0]);
+	destroy_buffer(&menu->scrim_buffers[1]);
 
 	menu_clear_items(menu);
 	menu->sni = NULL;
@@ -352,6 +521,11 @@ bool tray_menu_is_open(struct swaybar_menu *menu) {
 bool tray_menu_pointer_enter(struct swaybar_menu *menu,
 		struct wl_surface *surface) {
 	return menu && menu->surface == surface;
+}
+
+bool tray_menu_is_scrim(struct swaybar_menu *menu,
+		struct wl_surface *surface) {
+	return menu && menu->scrim_surface == surface;
 }
 
 void tray_menu_pointer_motion(struct swaybar_menu *menu, double x, double y) {
@@ -471,6 +645,8 @@ void tray_menu_render(struct swaybar_menu *menu) {
 	}
 
 	double y = MENU_PADDING_Y;
+	int tcw = menu->toggle_column_width;
+
 	for (int i = 0; i < menu->item_count; i++) {
 		struct swaybar_menu_item *item = &menu->items[i];
 
@@ -488,9 +664,49 @@ void tray_menu_render(struct swaybar_menu *menu) {
 		// Draw hover highlight
 		if (i == menu->hovered_index) {
 			cairo_set_source_u32(cairo, MENU_BG_HOVER_COLOR);
-			// Clip to rounded rect for items at top/bottom
 			cairo_rectangle(cairo, 2, y, w - 4, MENU_ITEM_HEIGHT);
 			cairo_fill(cairo);
+		}
+
+		double text_x = MENU_PADDING_X + tcw;
+
+		// Draw toggle indicator
+		if (item->toggle_type != MENU_TOGGLE_NONE) {
+			double cx = MENU_PADDING_X + MENU_TOGGLE_SIZE / 2.0;
+			double cy_center = y + MENU_ITEM_HEIGHT / 2.0;
+
+			if (item->toggle_type == MENU_TOGGLE_CHECKMARK) {
+				if (item->toggle_state == MENU_TOGGLE_STATE_ON) {
+					// Draw checkmark
+					cairo_set_source_u32(cairo, MENU_CHECK_COLOR);
+					cairo_set_line_width(cairo, 2.0);
+					cairo_move_to(cairo, cx - 4, cy_center);
+					cairo_line_to(cairo, cx - 1, cy_center + 3);
+					cairo_line_to(cairo, cx + 5, cy_center - 4);
+					cairo_stroke(cairo);
+				} else if (item->toggle_state == MENU_TOGGLE_STATE_INDETERMINATE) {
+					// Draw dash
+					cairo_set_source_u32(cairo, MENU_CHECK_COLOR);
+					cairo_set_line_width(cairo, 2.0);
+					cairo_move_to(cairo, cx - 4, cy_center);
+					cairo_line_to(cairo, cx + 4, cy_center);
+					cairo_stroke(cairo);
+				}
+			} else if (item->toggle_type == MENU_TOGGLE_RADIO) {
+				// Draw radio circle outline
+				cairo_set_source_u32(cairo, MENU_CHECK_COLOR);
+				cairo_set_line_width(cairo, 1.5);
+				cairo_arc(cairo, cx, cy_center, 5, 0, 2 * M_PI);
+				if (item->toggle_state == MENU_TOGGLE_STATE_ON) {
+					cairo_fill(cairo);
+					// Inner dot
+					cairo_set_source_u32(cairo, MENU_BG_COLOR);
+					cairo_arc(cairo, cx, cy_center, 2, 0, 2 * M_PI);
+					cairo_fill(cairo);
+				} else {
+					cairo_stroke(cairo);
+				}
+			}
 		}
 
 		// Draw label
@@ -505,9 +721,22 @@ void tray_menu_render(struct swaybar_menu *menu) {
 
 			int tw, th;
 			pango_layout_get_pixel_size(layout, &tw, &th);
-			cairo_move_to(cairo, MENU_PADDING_X,
+			cairo_move_to(cairo, text_x,
 					y + (MENU_ITEM_HEIGHT - th) / 2.0);
 			pango_cairo_show_layout(cairo, layout);
+		}
+
+		// Draw submenu arrow
+		if (item->has_submenu) {
+			double ax = w - MENU_PADDING_X - MENU_SUBMENU_ARROW_SIZE / 2.0;
+			double ay = y + MENU_ITEM_HEIGHT / 2.0;
+			cairo_set_source_u32(cairo, item->enabled ?
+					MENU_TEXT_COLOR : MENU_TEXT_DISABLED_COLOR);
+			cairo_move_to(cairo, ax - 3, ay - 5);
+			cairo_line_to(cairo, ax + 3, ay);
+			cairo_line_to(cairo, ax - 3, ay + 5);
+			cairo_close_path(cairo);
+			cairo_fill(cairo);
 		}
 
 		y += MENU_ITEM_HEIGHT;

--- a/swaybar/tray/menu.c
+++ b/swaybar/tray/menu.c
@@ -1,0 +1,523 @@
+#define _USE_MATH_DEFINES
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#include <assert.h>
+#include <cairo.h>
+#include <math.h>
+#include <pango/pangocairo.h>
+#include <stdlib.h>
+#include <string.h>
+#include <linux/input-event-codes.h>
+#include "swaybar/bar.h"
+#include "swaybar/config.h"
+#include "swaybar/tray/item.h"
+#include "swaybar/tray/menu.h"
+#include "swaybar/tray/tray.h"
+#include "cairo_util.h"
+#include "log.h"
+#include "pool-buffer.h"
+#include "wlr-layer-shell-unstable-v1-client-protocol.h"
+
+static void menu_layer_surface_configure(void *data,
+		struct zwlr_layer_surface_v1 *surface,
+		uint32_t serial, uint32_t width, uint32_t height) {
+	struct swaybar_menu *menu = data;
+	menu->width = width;
+	menu->height = height;
+	menu->configured = true;
+	zwlr_layer_surface_v1_ack_configure(surface, serial);
+	tray_menu_render(menu);
+}
+
+static void menu_layer_surface_closed(void *data,
+		struct zwlr_layer_surface_v1 *surface) {
+	struct swaybar_menu *menu = data;
+	tray_menu_close(menu);
+}
+
+static const struct zwlr_layer_surface_v1_listener menu_layer_surface_listener = {
+	.configure = menu_layer_surface_configure,
+	.closed = menu_layer_surface_closed,
+};
+
+struct swaybar_menu *tray_menu_create(struct swaybar *bar) {
+	struct swaybar_menu *menu = calloc(1, sizeof(struct swaybar_menu));
+	if (!menu) {
+		return NULL;
+	}
+	menu->bar = bar;
+	menu->hovered_index = -1;
+	return menu;
+}
+
+void tray_menu_destroy(struct swaybar_menu *menu) {
+	if (!menu) {
+		return;
+	}
+	tray_menu_close(menu);
+	free(menu);
+}
+
+static void menu_clear_items(struct swaybar_menu *menu) {
+	if (menu->items) {
+		for (int i = 0; i < menu->item_count; i++) {
+			free(menu->items[i].label);
+		}
+		free(menu->items);
+		menu->items = NULL;
+		menu->item_count = 0;
+	}
+}
+
+static int handle_menu_layout(sd_bus_message *msg, void *userdata,
+		sd_bus_error *error) {
+	struct swaybar_menu *menu = userdata;
+
+	if (sd_bus_message_is_method_error(msg, NULL)) {
+		const sd_bus_error *err = sd_bus_message_get_error(msg);
+		sway_log(SWAY_ERROR, "dbusmenu GetLayout failed: %s", err->message);
+		return -1;
+	}
+
+	menu_clear_items(menu);
+
+	uint32_t revision;
+	int ret = sd_bus_message_read(msg, "u", &revision);
+	if (ret < 0) return ret;
+
+	// Enter root struct (ia{sv}av)
+	ret = sd_bus_message_enter_container(msg, 'r', "ia{sv}av");
+	if (ret < 0) return ret;
+
+	int32_t root_id;
+	sd_bus_message_read(msg, "i", &root_id);
+
+	// Skip root properties
+	sd_bus_message_enter_container(msg, 'a', "{sv}");
+	while (sd_bus_message_enter_container(msg, 'e', "sv") > 0) {
+		sd_bus_message_skip(msg, "sv");
+		sd_bus_message_exit_container(msg);
+	}
+	sd_bus_message_exit_container(msg);
+
+	// Count children first by collecting into a temporary array
+	// We'll allocate generously and shrink later
+	int capacity = 64;
+	struct swaybar_menu_item *items = calloc(capacity, sizeof(struct swaybar_menu_item));
+	int count = 0;
+
+	ret = sd_bus_message_enter_container(msg, 'a', "v");
+	if (ret < 0) {
+		free(items);
+		return ret;
+	}
+
+	while (sd_bus_message_enter_container(msg, 'v', "(ia{sv}av)") > 0) {
+		sd_bus_message_enter_container(msg, 'r', "ia{sv}av");
+
+		int32_t item_id;
+		sd_bus_message_read(msg, "i", &item_id);
+
+		char *label = NULL;
+		bool is_separator = false;
+		bool enabled = true;
+		bool visible = true;
+
+		sd_bus_message_enter_container(msg, 'a', "{sv}");
+		while (sd_bus_message_enter_container(msg, 'e', "sv") > 0) {
+			const char *prop;
+			sd_bus_message_read(msg, "s", &prop);
+
+			if (strcmp(prop, "label") == 0) {
+				if (sd_bus_message_enter_container(msg, 'v', "s") >= 0) {
+					const char *val;
+					sd_bus_message_read(msg, "s", &val);
+					label = strdup(val);
+					sd_bus_message_exit_container(msg);
+				} else {
+					sd_bus_message_skip(msg, "v");
+				}
+			} else if (strcmp(prop, "type") == 0) {
+				if (sd_bus_message_enter_container(msg, 'v', "s") >= 0) {
+					const char *val;
+					sd_bus_message_read(msg, "s", &val);
+					if (strcmp(val, "separator") == 0) {
+						is_separator = true;
+					}
+					sd_bus_message_exit_container(msg);
+				} else {
+					sd_bus_message_skip(msg, "v");
+				}
+			} else if (strcmp(prop, "enabled") == 0) {
+				if (sd_bus_message_enter_container(msg, 'v', "b") >= 0) {
+					int val;
+					sd_bus_message_read(msg, "b", &val);
+					enabled = val;
+					sd_bus_message_exit_container(msg);
+				} else {
+					sd_bus_message_skip(msg, "v");
+				}
+			} else if (strcmp(prop, "visible") == 0) {
+				if (sd_bus_message_enter_container(msg, 'v', "b") >= 0) {
+					int val;
+					sd_bus_message_read(msg, "b", &val);
+					visible = val;
+					sd_bus_message_exit_container(msg);
+				} else {
+					sd_bus_message_skip(msg, "v");
+				}
+			} else {
+				sd_bus_message_skip(msg, "v");
+			}
+			sd_bus_message_exit_container(msg); // dict entry
+		}
+		sd_bus_message_exit_container(msg); // a{sv}
+
+		// Skip children
+		sd_bus_message_skip(msg, "av");
+		sd_bus_message_exit_container(msg); // (ia{sv}av)
+		sd_bus_message_exit_container(msg); // v
+
+		if (visible && count < capacity) {
+			items[count].id = item_id;
+			items[count].label = label ? label : (is_separator ? NULL : strdup("???"));
+			items[count].is_separator = is_separator;
+			items[count].enabled = enabled && !is_separator;
+			count++;
+		} else {
+			free(label);
+		}
+	}
+
+	menu->items = items;
+	menu->item_count = count;
+
+	sway_log(SWAY_DEBUG, "dbusmenu: loaded %d menu items", count);
+
+	// Now compute size and create/show the surface
+	int max_text_width = MENU_MIN_WIDTH;
+	PangoLayout *layout = NULL;
+
+	// We need a temporary cairo surface to measure text
+	cairo_surface_t *tmp = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 1, 1);
+	cairo_t *cr = cairo_create(tmp);
+	layout = pango_cairo_create_layout(cr);
+
+	if (menu->bar->config->font_description) {
+		pango_layout_set_font_description(layout,
+				menu->bar->config->font_description);
+	}
+
+	for (int i = 0; i < count; i++) {
+		if (!items[i].is_separator && items[i].label) {
+			pango_layout_set_text(layout, items[i].label, -1);
+			int w, h;
+			pango_layout_get_pixel_size(layout, &w, &h);
+			if (w > max_text_width) {
+				max_text_width = w;
+			}
+		}
+	}
+
+	g_object_unref(layout);
+	cairo_destroy(cr);
+	cairo_surface_destroy(tmp);
+
+	// Calculate total menu size
+	int total_height = MENU_PADDING_Y * 2; // top/bottom padding
+	for (int i = 0; i < count; i++) {
+		total_height += items[i].is_separator ? MENU_SEPARATOR_HEIGHT : MENU_ITEM_HEIGHT;
+	}
+	int total_width = max_text_width + MENU_PADDING_X * 2;
+
+	// Create the layer surface
+	if (menu->layer_surface) {
+		// Already have a surface, just resize
+		zwlr_layer_surface_v1_set_size(menu->layer_surface, total_width, total_height);
+		wl_surface_commit(menu->surface);
+	} else {
+		menu->surface = wl_compositor_create_surface(menu->bar->compositor);
+		assert(menu->surface);
+
+		menu->layer_surface = zwlr_layer_shell_v1_get_layer_surface(
+				menu->bar->layer_shell, menu->surface, menu->output->output,
+				ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY, "menu");
+		assert(menu->layer_surface);
+
+		zwlr_layer_surface_v1_add_listener(menu->layer_surface,
+				&menu_layer_surface_listener, menu);
+
+		// Anchor to bottom-right to position near the tray
+		struct swaybar_config *config = menu->bar->config;
+		bool top_bar = config->position & ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
+
+		if (top_bar) {
+			zwlr_layer_surface_v1_set_anchor(menu->layer_surface,
+					ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
+					ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
+			// Margin: push down from top by bar height, push left from right edge
+			int right_margin = menu->output->width - menu->anchor_x - total_width / 2;
+			if (right_margin < 0) right_margin = 0;
+			int top_margin = menu->output->height > 0 ?
+					(int)menu->output->height : 30;
+			zwlr_layer_surface_v1_set_margin(menu->layer_surface,
+					top_margin + 4, right_margin, 0, 0);
+		} else {
+			zwlr_layer_surface_v1_set_anchor(menu->layer_surface,
+					ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM |
+					ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
+			// Margin: push up from bottom by bar height
+			int right_margin = menu->output->width - menu->anchor_x - total_width / 2;
+			if (right_margin < 0) right_margin = 0;
+			int bottom_margin = menu->output->height > 0 ?
+					(int)menu->output->height : 30;
+			zwlr_layer_surface_v1_set_margin(menu->layer_surface,
+					0, right_margin, bottom_margin + 4, 0);
+		}
+
+		zwlr_layer_surface_v1_set_size(menu->layer_surface, total_width, total_height);
+		zwlr_layer_surface_v1_set_exclusive_zone(menu->layer_surface, -1);
+		// Allow keyboard interaction
+		zwlr_layer_surface_v1_set_keyboard_interactivity(menu->layer_surface,
+				ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_ON_DEMAND);
+
+		wl_surface_commit(menu->surface);
+	}
+
+	return 0;
+}
+
+void tray_menu_open(struct swaybar_menu *menu, struct swaybar_sni *sni,
+		struct swaybar_output *output, int anchor_x) {
+	if (!menu || !sni || !sni->menu) {
+		return;
+	}
+
+	// Close existing menu first
+	if (menu->layer_surface) {
+		tray_menu_close(menu);
+	}
+
+	menu->sni = sni;
+	menu->output = output;
+	menu->anchor_x = anchor_x;
+	menu->hovered_index = -1;
+	menu->configured = false;
+
+	sway_log(SWAY_DEBUG, "Opening tray menu for %s at x=%d", sni->watcher_id, anchor_x);
+
+	// Call AboutToShow first, then GetLayout
+	sd_bus_call_method_async(sni->tray->bus, NULL, sni->service,
+			sni->menu, "com.canonical.dbusmenu", "AboutToShow",
+			NULL, NULL, "i", (int32_t)0);
+
+	sd_bus_call_method_async(sni->tray->bus, NULL, sni->service,
+			sni->menu, "com.canonical.dbusmenu", "GetLayout",
+			handle_menu_layout, menu, "iias", (int32_t)0, (int32_t)1, 0);
+}
+
+void tray_menu_close(struct swaybar_menu *menu) {
+	if (!menu) {
+		return;
+	}
+
+	sway_log(SWAY_DEBUG, "Closing tray menu");
+
+	if (menu->layer_surface) {
+		zwlr_layer_surface_v1_destroy(menu->layer_surface);
+		menu->layer_surface = NULL;
+	}
+	if (menu->surface) {
+		wl_surface_destroy(menu->surface);
+		menu->surface = NULL;
+	}
+
+	destroy_buffer(&menu->buffers[0]);
+	destroy_buffer(&menu->buffers[1]);
+
+	menu_clear_items(menu);
+	menu->sni = NULL;
+	menu->output = NULL;
+	menu->configured = false;
+	menu->width = 0;
+	menu->height = 0;
+}
+
+bool tray_menu_is_open(struct swaybar_menu *menu) {
+	return menu && menu->layer_surface != NULL;
+}
+
+bool tray_menu_pointer_enter(struct swaybar_menu *menu,
+		struct wl_surface *surface) {
+	return menu && menu->surface == surface;
+}
+
+void tray_menu_pointer_motion(struct swaybar_menu *menu, double x, double y) {
+	if (!menu || !menu->items) {
+		return;
+	}
+
+	int old_hover = menu->hovered_index;
+	menu->hovered_index = -1;
+
+	double cy = MENU_PADDING_Y;
+	for (int i = 0; i < menu->item_count; i++) {
+		double item_h = menu->items[i].is_separator ?
+				MENU_SEPARATOR_HEIGHT : MENU_ITEM_HEIGHT;
+		if (y >= cy && y < cy + item_h && !menu->items[i].is_separator
+				&& menu->items[i].enabled) {
+			menu->hovered_index = i;
+			break;
+		}
+		cy += item_h;
+	}
+
+	if (menu->hovered_index != old_hover) {
+		tray_menu_render(menu);
+	}
+}
+
+bool tray_menu_pointer_button(struct swaybar_menu *menu, uint32_t button,
+		uint32_t state) {
+	if (!menu || !tray_menu_is_open(menu)) {
+		return false;
+	}
+
+	if (state != WL_POINTER_BUTTON_STATE_PRESSED) {
+		return true; // consume release too
+	}
+
+	if (button == BTN_LEFT && menu->hovered_index >= 0) {
+		struct swaybar_menu_item *item = &menu->items[menu->hovered_index];
+		sway_log(SWAY_INFO, "Menu item clicked: id=%d label='%s'",
+				item->id, item->label ? item->label : "");
+
+		// Send dbusmenu Event
+		if (menu->sni && menu->sni->menu) {
+			sd_bus_call_method_async(menu->sni->tray->bus, NULL,
+					menu->sni->service, menu->sni->menu,
+					"com.canonical.dbusmenu", "Event",
+					NULL, NULL, "isvu", item->id, "clicked", "s", "",
+					(uint32_t)0);
+		}
+		tray_menu_close(menu);
+		return true;
+	}
+
+	// Any other click closes the menu
+	tray_menu_close(menu);
+	return true;
+}
+
+void tray_menu_pointer_leave(struct swaybar_menu *menu) {
+	if (!menu) {
+		return;
+	}
+	if (menu->hovered_index != -1) {
+		menu->hovered_index = -1;
+		tray_menu_render(menu);
+	}
+}
+
+void tray_menu_render(struct swaybar_menu *menu) {
+	if (!menu || !menu->configured || !menu->surface || !menu->layer_surface) {
+		return;
+	}
+	if (menu->width == 0 || menu->height == 0 || menu->item_count == 0) {
+		return;
+	}
+
+	int scale = menu->output ? menu->output->scale : 1;
+	struct pool_buffer *buffer = get_next_buffer(menu->bar->shm,
+			menu->buffers, menu->width * scale, menu->height * scale);
+	if (!buffer) {
+		sway_log(SWAY_ERROR, "Failed to get buffer for menu");
+		return;
+	}
+
+	cairo_t *cairo = buffer->cairo;
+	cairo_save(cairo);
+	cairo_set_operator(cairo, CAIRO_OPERATOR_CLEAR);
+	cairo_paint(cairo);
+	cairo_restore(cairo);
+
+	cairo_scale(cairo, scale, scale);
+
+	// Draw background with rounded corners
+	double w = menu->width;
+	double h = menu->height;
+	double r = 8.0; // corner radius
+
+	cairo_new_path(cairo);
+	cairo_arc(cairo, r, r, r, M_PI, 1.5 * M_PI);
+	cairo_arc(cairo, w - r, r, r, 1.5 * M_PI, 2 * M_PI);
+	cairo_arc(cairo, w - r, h - r, r, 0, 0.5 * M_PI);
+	cairo_arc(cairo, r, h - r, r, 0.5 * M_PI, M_PI);
+	cairo_close_path(cairo);
+
+	cairo_set_source_u32(cairo, MENU_BG_COLOR);
+	cairo_fill_preserve(cairo);
+	cairo_set_source_u32(cairo, MENU_BORDER_COLOR);
+	cairo_set_line_width(cairo, 1.0);
+	cairo_stroke(cairo);
+
+	// Draw menu items
+	PangoLayout *layout = pango_cairo_create_layout(cairo);
+	if (menu->bar->config->font_description) {
+		pango_layout_set_font_description(layout,
+				menu->bar->config->font_description);
+	}
+
+	double y = MENU_PADDING_Y;
+	for (int i = 0; i < menu->item_count; i++) {
+		struct swaybar_menu_item *item = &menu->items[i];
+
+		if (item->is_separator) {
+			// Draw separator line
+			cairo_set_source_u32(cairo, MENU_SEPARATOR_COLOR);
+			cairo_set_line_width(cairo, 1.0);
+			cairo_move_to(cairo, MENU_PADDING_X / 2.0, y + MENU_SEPARATOR_HEIGHT / 2.0);
+			cairo_line_to(cairo, w - MENU_PADDING_X / 2.0, y + MENU_SEPARATOR_HEIGHT / 2.0);
+			cairo_stroke(cairo);
+			y += MENU_SEPARATOR_HEIGHT;
+			continue;
+		}
+
+		// Draw hover highlight
+		if (i == menu->hovered_index) {
+			cairo_set_source_u32(cairo, MENU_BG_HOVER_COLOR);
+			// Clip to rounded rect for items at top/bottom
+			cairo_rectangle(cairo, 2, y, w - 4, MENU_ITEM_HEIGHT);
+			cairo_fill(cairo);
+		}
+
+		// Draw label
+		if (item->label) {
+			pango_layout_set_text(layout, item->label, -1);
+
+			if (item->enabled) {
+				cairo_set_source_u32(cairo, MENU_TEXT_COLOR);
+			} else {
+				cairo_set_source_u32(cairo, MENU_TEXT_DISABLED_COLOR);
+			}
+
+			int tw, th;
+			pango_layout_get_pixel_size(layout, &tw, &th);
+			cairo_move_to(cairo, MENU_PADDING_X,
+					y + (MENU_ITEM_HEIGHT - th) / 2.0);
+			pango_cairo_show_layout(cairo, layout);
+		}
+
+		y += MENU_ITEM_HEIGHT;
+	}
+
+	g_object_unref(layout);
+
+	// Commit the surface
+	wl_surface_set_buffer_scale(menu->surface, scale);
+	wl_surface_attach(menu->surface, buffer->buffer, 0, 0);
+	wl_surface_damage(menu->surface, 0, 0, menu->width, menu->height);
+	wl_surface_commit(menu->surface);
+}

--- a/swaybar/tray/tray.c
+++ b/swaybar/tray/tray.c
@@ -8,6 +8,7 @@
 #include "swaybar/tray/icon.h"
 #include "swaybar/tray/host.h"
 #include "swaybar/tray/item.h"
+#include "swaybar/tray/menu.h"
 #include "swaybar/tray/tray.h"
 #include "swaybar/tray/watcher.h"
 #include "list.h"
@@ -70,6 +71,8 @@ struct swaybar_tray *create_tray(struct swaybar *bar) {
 
 	init_themes(&tray->themes, &tray->basedirs);
 
+	tray->menu = tray_menu_create(bar);
+
 	return tray;
 }
 
@@ -77,6 +80,7 @@ void destroy_tray(struct swaybar_tray *tray) {
 	if (!tray) {
 		return;
 	}
+	tray_menu_destroy(tray->menu);
 	finish_host(&tray->host_xdg);
 	finish_host(&tray->host_kde);
 	for (int i = 0; i < tray->items->length; ++i) {


### PR DESCRIPTION
## Summary

Adds full dbusmenu-based popup menu support for StatusNotifierItem (SNI) tray icons in swaybar, fixing left-click activation and right-click context menus for apps like Steam and pCloud.

## Problem

Many tray applications (especially ayatana-based ones like Steam) register via the SNI protocol but lack native `Activate` or `ContextMenu` D-Bus methods. Other apps (like pCloud) have native `ContextMenu` but it creates an XWayland popup that cannot be dismissed by clicking on Wayland surfaces. This makes tray icons in swaybar effectively non-functional.

## Solution

- **Left-click**: For ayatana SNI items without an `Activate` method, query the dbusmenu layout and send a `clicked` event to the first actionable menu item
- **Right-click**: For any SNI with a `Menu` D-Bus property, render a custom popup menu by querying the dbusmenu layout, displayed as a layer-shell overlay surface
- **Click-outside-to-dismiss**: An invisible fullscreen scrim surface on the overlay layer catches clicks outside the menu to dismiss it

## Menu features

- Full dbusmenu property parsing: labels, toggle types (checkmark/radio), toggle state, separators, submenu indicators
- Icon rendering: supports both `icon-name` (themed) and `icon-data` (PNG byte arrays) with scaling to 16x16
- Hover highlighting, separator rendering, proper font handling via Pango
- Pointer input handling with enter/leave/motion/button events

## Files changed

- **New**: `include/swaybar/tray/menu.h`, `swaybar/tray/menu.c` — popup menu implementation
- **Modified**: `swaybar/tray/item.c` — ayatana detection, dbusmenu activation, popup triggering
- **Modified**: `swaybar/input.c` — pointer event routing for menu/scrim surfaces
- **Modified**: `include/swaybar/input.h`, `include/swaybar/tray/tray.h`, `swaybar/tray/tray.c`, `swaybar/meson.build` — supporting changes