### PR TITLE
fix: skip animation setup for containers being destroyed

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -911,7 +911,8 @@ static void transaction_apply(struct sway_transaction *transaction) {
 			break;
 		case N_CONTAINER:
 			struct sway_container *con = node->sway_container;
-			if (should_con_new_animation(con, &instruction->container_state)) {
+			if (!node->destroying &&
+					should_con_new_animation(con, &instruction->container_state)) {
 				should_start_new_animation = true;
 
 				// TODO: reset animation state on going to scratchpad


### PR DESCRIPTION
## Summary

Fix a heap-use-after-free crash that occurs when multiple windows are closed rapidly.

- **Root cause:** `transaction_apply()` accesses `con->animation_state` on containers already freed by `view_unmap()`
- **Fix:** skip animation setup when `node->destroying` is set

Full analysis in #519.

## Test plan

1. Build with ASan: `meson setup build -Db_sanitize=address -Db_lundef=false`
2. Open ~10 windows (e.g., Qutebrowser)
3. Close all windows simultaneously
4. **Before fix:** SIGABRT / SIGSEGV (ASan reports heap-use-after-free)
5. **After fix:** no crash, no ASan errors