### PR TITLE
Allow `move position` command to calculate from right and/or bottom edge

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -809,7 +809,9 @@ static struct cmd_results *cmd_move_to_position_pointer(
 }
 
 static const char expected_position_syntax[] =
-	"Expected 'move [absolute] position <x> [px] <y> [px]' or "
+	"Expected "
+	"'move [absolute] position [left|right] <x> [px|ppt] [top|bottom] <y> [px|ppt]' "
+	"or "
 	"'move [absolute] position center' or "
 	"'move position cursor|mouse|pointer'";
 
@@ -825,6 +827,8 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 	}
 
 	bool absolute = false;
+	bool right = false;
+	bool bottom = false;
 	if (strcmp(argv[0], "absolute") == 0) {
 		absolute = true;
 		--argc;
@@ -864,6 +868,16 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
 
+	// If we reach here, we are expecting a specific numeric position.
+	// First check if there is a left/right keyword:
+	bool isLeft = argc > 0 && strcmp(argv[0], "left") == 0;
+	bool isRight = argc > 0 && strcmp(argv[0], "right") == 0;
+	if (isLeft || isRight) {
+		right = isRight;
+		--argc;
+		++argv;
+	}
+
 	if (argc < 2) {
 		return cmd_results_new(CMD_FAILURE, "%s", expected_position_syntax);
 	}
@@ -875,6 +889,15 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 	argv += num_consumed_args;
 	if (lx.unit == MOVEMENT_UNIT_INVALID) {
 		return cmd_results_new(CMD_INVALID, "Invalid x position specified");
+	}
+
+	// Now check if there is a top/bottom keyword:
+	bool isTop = argc > 0 && strcmp(argv[0], "top") == 0;
+	bool isBottom = argc > 0 && strcmp(argv[0], "bottom") == 0;
+	if (isTop || isBottom) {
+		bottom = isBottom;
+		--argc;
+		++argv;
 	}
 
 	if (argc < 1) {
@@ -942,6 +965,25 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 		sway_assert(false, "invalid y unit");
 		break;
 	}
+
+	// Adjust movement amounts for right and bottom offsets if need be:
+	if (right) {
+		if (absolute) {
+			lx.amount = root->x + root->width - lx.amount
+				- container->pending.width;
+		} else {
+			lx.amount = ws->width - lx.amount - container->pending.width;
+		}
+	}
+	if (bottom) {
+		if (absolute) {
+			ly.amount = root->y + root->height - ly.amount
+				- container->pending.height;
+		} else {
+			ly.amount = ws->height - ly.amount - container->pending.height;
+		}
+	}
+
 	if (!absolute) {
 		lx.amount += ws->x;
 		ly.amount += ws->y;

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -408,27 +408,29 @@ static void arrange_container(struct sway_container *con,
 	// make sure it's enabled for viewing
 	wlr_scene_node_set_enabled(&con->scene_tree->node, true);
 
-	if (con->view) {
-		// reuse the position from arrange_child. A bit hacky, but this reduces diff size vs upstream.
-		int x = get_animated_value(con->scene_tree->node.x + con->animation_state.delta_x,
-			con->scene_tree->node.x, *con->animation_state.animation);
-		int y = get_animated_value(con->scene_tree->node.y + con->animation_state.delta_y,
-			con->scene_tree->node.y, *con->animation_state.animation);
-		wlr_scene_node_set_position(&con->scene_tree->node, x, y);
+	if (!con->node.destroying) {
+		if (con->view) {
+			// reuse the position from arrange_child. A bit hacky, but this reduces diff size vs upstream.
+			int x = get_animated_value(con->scene_tree->node.x + con->animation_state.delta_x,
+				con->scene_tree->node.x, *con->animation_state.animation);
+			int y = get_animated_value(con->scene_tree->node.y + con->animation_state.delta_y,
+				con->scene_tree->node.y, *con->animation_state.animation);
+			wlr_scene_node_set_position(&con->scene_tree->node, x, y);
 
-		width = get_animated_value(width + con->animation_state.delta_width, width,
-			*con->animation_state.animation);
-		if (width <= 0) {
-			return;
+			width = get_animated_value(width + con->animation_state.delta_width, width,
+				*con->animation_state.animation);
+			if (width <= 0) {
+				return;
+			}
+			height = get_animated_value(height + con->animation_state.delta_height, height,
+				*con->animation_state.animation);
+			if (height <= 0) {
+				return;
+			}
 		}
-		height = get_animated_value(height + con->animation_state.delta_height, height,
-			*con->animation_state.animation);
-		if (height <= 0) {
-			return;
-		}
+		con->animation_state.current_width = width;
+		con->animation_state.current_height = height;
 	}
-	con->animation_state.current_width = width;
-	con->animation_state.current_height = height;
 
 	if (con->output_handler) {
 		wlr_scene_buffer_set_dest_size(con->output_handler, width, height);
@@ -571,12 +573,11 @@ static void arrange_container(struct sway_container *con,
 			};
 			wlr_scene_subsurface_tree_set_clip(&con->view->content_tree->node, &clip);
 		}
-		con->animation_state.current_content_width = content_width;
-		if (content_width <= 0) {
-			return;
+		if (!con->node.destroying) {
+			con->animation_state.current_content_width = content_width;
+			con->animation_state.current_content_height = content_height;
 		}
-		con->animation_state.current_content_height = content_height;
-		if (content_height <= 0) {
+		if (content_width <= 0 || content_height <= 0) {
 			return;
 		}
 
@@ -871,6 +872,9 @@ void animation_update_callback() {
 }
 
 static bool should_con_new_animation(struct sway_container *con, struct sway_container_state *new_state) {
+	if (con->node.destroying) {
+		return false;
+	}
 	return con->current.width != new_state->width ||
 		con->current.height != new_state->height ||
 		con->current.x != new_state->x ||

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -240,11 +240,18 @@ set|plus|minus|toggle <amount>
 	argument specifies how many pixels to move the container. If unspecified,
 	the default is 10 pixels. Pixels are ignored when moving tiled containers.
 
-*move* [absolute] position <pos_x> [px|ppt] <pos_y> [px|ppt]
+*move* [absolute] position [left|right] <pos_x> [px|ppt] [top|bottom] <pos_y> [px|ppt]
 	Moves the focused container to the specified position in the workspace.
 	The position can be specified in pixels or percentage points, omitting
-	the unit defaults to pixels. If _absolute_ is used, the position is
-	relative to all outputs. _absolute_ can not be used with percentage points.
+	the unit defaults to pixels. Each coordinate may be prefixed with a keyword
+	to indicate which edge of the container is being offset: for the horizontal
+	position, this may be "left" to indicate how far left the left edge of the
+	container should be from the left workspace edge, or "right" to indicate
+	how far the right edge should be from the right of the workspace. The
+	keywords "top" and "bottom" work similarly for the vertical position. Absent
+	keywords correspond to "left" and "top", respectively. If _absolute_ is used,
+	the position is relative to all outputs. _absolute_ can not be used with
+	percentage points, but the directional keywords still apply.
 
 *move* [absolute] position center
 	Moves the focused container to be centered on the workspace. If _absolute_


### PR DESCRIPTION
Unlike Xorg geometry specifications (e.g. `80x30-10-10`) or CSS specifications (using `right` and `bottom` properties), prior to this PR SwayFX has no way to specify a window position as an offset to the right edge or bottom edge of its containing workspace. However, it is convenient to have such a mechanism for positioning a window in, say, the bottom right corner of the screen.

This PR adds optional `left`/`right` and `top`/`bottom` keywords before each dimension of the `move position <dim> <dim>` command. To preserve the behavior of existing config files/sway commands, omitted keywords on each dimension behave like `left` and `top` respectively.

Note that partial credit for this PR should go to @cizra, who filed a [similar PR](https://github.com/swaywm/sway/pull/9058) with sway itself. If the sway team shows interest in the somewhat refined version as filed here, we will likely file a very similar or identical PR to sway.

I wasn't sure if there were any other steps in generating a PR besides the code and documentation changes in the one commit of this PR? I didn't see any test suite that I should add to. If there are other tasks, please just let me know. In any case, this change can be tested by issuing a variety of `swaymsg` commands, such as:
```
swaymsg move position left 10 bottom 10
swaymsg move position right 0 top 10
swaymsg -- move position -5 top -5
swaymsg move position right 10ppt 20ppt
swaymsg move position 3px 5px
```