### PR TITLE
chore: update Sway's `original_version` to 1.12.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ project(
 	],
 )
 
-original_version = '1.11.0'
+original_version = '1.12.0'
 
 add_project_arguments(
 	[


### PR DESCRIPTION
I am not sure whether this was left at 1.11 intentionally or not; please just close if this is still supposed to be 1.11.0.

CC @WillPower3309